### PR TITLE
Redesign: Microsoft Windows 2000 aesthetic

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -34,63 +34,83 @@
 }
 
 @theme {
-  --font-sans:
-    "Proxima Nova", "Avenir Next", "Helvetica Neue", Helvetica, Arial, "Segoe UI", sans-serif;
+  --font-sans: "Proxima Nova", "Tahoma", "MS Sans Serif", "Arial", sans-serif;
+  --font-mono: "Courier New", "Lucida Console", monospace;
 
   --container-8xl: 90rem;
   --breakpoint-md: 650px;
-  --breakpoint-md: 1025px;
+  --breakpoint-lg: 1025px;
 
-  --container-8xl: 90rem;
-  --breakpoint-md: 650px;
-  --breakpoint-md: 1025px;
+  /* Windows 2000 color palette */
+  --color-win-gray-light:   #d4d0c8;
+  --color-win-gray-mid:     #c0bdb4;
+  --color-win-gray-dark:    #808080;
+  --color-win-gray-shadow:  #404040;
+  --color-win-white:        #ffffff;
+  --color-win-black:        #000000;
+  --color-win-teal:         #008080;
+  --color-win-teal-dark:    #005f5f;
+  --color-win-navy:         #000080;
+  --color-win-titlebar:     #000080;
+  --color-win-titlebar-end: #1084d0;
+  --color-win-button-face:  #d4d0c8;
+  --color-win-button-text:  #000000;
+  --color-win-desktop:      #008080;
+  --color-win-highlight:    #0a246a;
+  --color-win-highlight-text: #ffffff;
+  --color-win-link:         #0000ee;
+  --color-win-visited:      #551a8b;
+  --color-win-red:          #c0392b;
+  --color-win-yellow:       #ffff00;
+  --color-win-green:        #008000;
 
+  /* Keep envision brand tokens for fallback */
   --color-envision-blue-50: oklch(0.978 0.011 234.814);
   --color-envision-blue-100: oklch(0.95 0.022 239.429);
   --color-envision-blue-200: oklch(0.896 0.049 234.187);
   --color-envision-blue-300: oklch(0.815 0.091 233.14);
   --color-envision-blue-400: oklch(0.733 0.128 233.733);
-  --color-envision-blue-500: oklch(0.634 0.135 238.396);
-  --color-envision-blue-600: oklch(0.56 0.132 243.136);
-  --color-envision-blue-700: oklch(0.478 0.112 243.857);
-  --color-envision-blue-800: oklch(0.427 0.093 241.472);
-  --color-envision-blue-900: oklch(0.378 0.079 242.34);
-  --color-envision-blue-950: oklch(0.284 0.059 245.802);
+  --color-envision-blue-500: #1084d0;
+  --color-envision-blue-600: #000080;
+  --color-envision-blue-700: #000080;
+  --color-envision-blue-800: #000070;
+  --color-envision-blue-900: #000060;
+  --color-envision-blue-950: #000050;
 
-  --color-envision-green-50: oklch(0.932 0.166 130.998);
-  --color-envision-green-100: oklch(0.88 0.144 140.43);
-  --color-envision-green-200: oklch(0.8 0.156 140.463);
-  --color-envision-green-300: oklch(0.72 0.164 140.459);
-  --color-envision-green-400: oklch(0.641 0.17 140.385);
-  --color-envision-green-500: oklch(0.551 0.169 140.275);
-  --color-envision-green-600: oklch(0.482 0.162 142.025);
-  --color-envision-green-700: oklch(0.405 0.138 142.495);
-  --color-envision-green-800: oklch(0.332 0.113 142.495);
-  --color-envision-green-900: oklch(0.254 0.086 142.495);
-  --color-envision-green-950: oklch(0.154 0.052 142.495);
+  --color-envision-green-50:  #e8f5e8;
+  --color-envision-green-100: #c8e6c8;
+  --color-envision-green-200: #a4d4a4;
+  --color-envision-green-300: #80c080;
+  --color-envision-green-400: #50a050;
+  --color-envision-green-500: #008000;
+  --color-envision-green-600: #006800;
+  --color-envision-green-700: #005000;
+  --color-envision-green-800: #003800;
+  --color-envision-green-900: #002000;
+  --color-envision-green-950: #001000;
 
-  --color-envision-gray-300: oklch(0.8733 0.0014 286.37);
-  --color-envision-gray-400: oklch(0.7287 0.0014 286.36);
-  --color-envision-gray-500: oklch(0.5474 0.0062 297.62);
-  --color-envision-gray-600: oklch(0.407 0.0052 236.62);
-  --color-envision-gray-700: oklch(0.3298 0.0066 229.02);
-  --color-envision-gray-900: oklch(0.2103 0.0059 285.89);
+  --color-envision-gray-300: #d4d0c8;
+  --color-envision-gray-400: #c0bdb4;
+  --color-envision-gray-500: #808080;
+  --color-envision-gray-600: #606060;
+  --color-envision-gray-700: #404040;
+  --color-envision-gray-900: #d4d0c8;
 
-  --ui-border: var(--color-envision-gray-500);
+  --ui-border: #808080;
 
   --text-xs: 0.64rem;
   --text-sm: 0.8rem;
   --text-base: 1rem;
-  --text-lg: 1.25rem;
-  --text-xl: 1.562rem;
-  --text-2xl: 1.953rem;
-  --text-3xl: 2.441rem;
-  --text-4xl: 3.052rem;
-  --text-5xl: 3.815rem;
-  --text-6xl: 4.57rem;
-  --text-7xl: 6.25rem;
-  --text-8xl: 8rem;
-  --text-9xl: 9.25rem;
+  --text-lg: 1.15rem;
+  --text-xl: 1.35rem;
+  --text-2xl: 1.6rem;
+  --text-3xl: 2rem;
+  --text-4xl: 2.5rem;
+  --text-5xl: 3rem;
+  --text-6xl: 3.5rem;
+  --text-7xl: 4.5rem;
+  --text-8xl: 6rem;
+  --text-9xl: 7.5rem;
 
   --border-main: 1px solid var(--ui-border);
 }
@@ -98,39 +118,76 @@
 :root {
   interpolate-size: allow-keywords;
 
-  --ui-primary: var(--color-envision-blue-500);
-  --ui-secondary: var(--color-envision-green-500);
+  --ui-primary: var(--color-win-navy);
+  --ui-secondary: var(--color-win-teal);
   --ui-container: var(--container-8xl);
+  --ui-border: #808080;
 
-  --ui-border: var(--color-envision-gray-500);
-  --color-white: oklch(1 0 0);
-  --text-color-muted: var(--color-envision-gray-600);
+  --color-white: #ffffff;
+  --color-background: var(--color-win-gray-light);
+  --color-foreground: var(--color-win-black);
+  --text-color-muted: #606060;
+
+  /* Win2K raised/sunken border mixins */
+  --win-border-raised:
+    inset -1px -1px 0 #404040,
+    inset 1px 1px 0 #ffffff,
+    inset -2px -2px 0 #808080,
+    inset 2px 2px 0 #d4d0c8;
+  --win-border-sunken:
+    inset 1px 1px 0 #404040,
+    inset -1px -1px 0 #ffffff,
+    inset 2px 2px 0 #808080,
+    inset -2px -2px 0 #d4d0c8;
+  --win-border-button:
+    inset -1px -1px 0 #000000,
+    inset 1px 1px 0 #ffffff,
+    inset -2px -2px 0 #808080,
+    inset 2px 2px 0 #d4d0c8;
+  --win-titlebar: linear-gradient(to right, #000080, #1084d0);
 
   --vw: 1vw;
-  --font-size-text-t1: clamp(18px, 0.0125 * calc(100 * var(--vw, 1vw)), 18px);
-  --font-size-text-t2: clamp(16px, 0.0111111111 * calc(100 * var(--vw, 1vw)), 16px);
-  --font-size-text-t3: clamp(14px, 0.0097222222 * calc(100 * var(--vw, 1vw)), 14px);
-  --font-size-text-t4: clamp(12px, 0.0083333333 * calc(100 * var(--vw, 1vw)), 12px);
+  --font-size-text-t1: clamp(14px, 0.0125 * calc(100 * var(--vw, 1vw)), 16px);
+  --font-size-text-t2: clamp(12px, 0.0111111111 * calc(100 * var(--vw, 1vw)), 14px);
+  --font-size-text-t3: clamp(11px, 0.0097222222 * calc(100 * var(--vw, 1vw)), 13px);
+  --font-size-text-t4: clamp(10px, 0.0083333333 * calc(100 * var(--vw, 1vw)), 12px);
 
-  --font-size-huge: clamp(50px, 0.081666667 * calc(100 * var(--vw, 1vw)), 75px);
-  --font-size-h1: clamp(50px, 0.0520833333 * calc(100 * var(--vw, 1vw)), 55px);
-  --font-size-h2: clamp(35px, 0.0481944444 * calc(100 * var(--vw, 1vw)), 45px);
-  --font-size-h3: clamp(30px, 0.0243055556 * calc(100 * var(--vw, 1vw)), 35px);
-  --font-size-h4: clamp(22px, 0.0152777778 * calc(100 * var(--vw, 1vw)), 22px);
+  --font-size-huge: clamp(28px, 0.05 * calc(100 * var(--vw, 1vw)), 48px);
+  --font-size-h1: clamp(24px, 0.035 * calc(100 * var(--vw, 1vw)), 36px);
+  --font-size-h2: clamp(20px, 0.028 * calc(100 * var(--vw, 1vw)), 28px);
+  --font-size-h3: clamp(16px, 0.02 * calc(100 * var(--vw, 1vw)), 22px);
+  --font-size-h4: clamp(14px, 0.015 * calc(100 * var(--vw, 1vw)), 18px);
 
   --border: 1px solid var(--ui-border);
-
   --spacing: 0.25rem;
 }
 
 html {
   overscroll-behavior: none;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  -ms-overflow-style: auto;
+  scrollbar-width: auto;
+  scrollbar-color: #d4d0c8 #808080;
 }
 
 html::-webkit-scrollbar {
-  display: none;
+  display: block;
+  width: 16px;
+}
+
+html::-webkit-scrollbar-track {
+  background: #d4d0c8;
+  border-left: 1px solid #808080;
+}
+
+html::-webkit-scrollbar-thumb {
+  background: #d4d0c8;
+  box-shadow: var(--win-border-raised);
+}
+
+html::-webkit-scrollbar-button {
+  background: #d4d0c8;
+  box-shadow: var(--win-border-raised);
+  height: 16px;
 }
 
 html:has(dialog[open]) {
@@ -138,11 +195,145 @@ html:has(dialog[open]) {
 }
 
 body {
-  background-color: var(--color-envision-gray-900);
-  color: oklch(1 0 0);
+  background-color: var(--color-win-gray-light);
+  color: var(--color-win-black);
+  font-family: "Tahoma", "MS Sans Serif", "Arial", sans-serif;
+  font-size: 11px;
+}
 
-  @media (min-width: 768px) {
-  }
+/* Win2K utility classes */
+.win-panel {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  padding: 2px;
+}
+
+.win-panel-sunken {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+}
+
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #ffffff;
+  font-weight: bold;
+  font-size: 11px;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+.win-titlebar-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", "MS Sans Serif", "Arial", sans-serif;
+  font-size: 11px;
+  padding: 3px 10px 4px;
+  cursor: pointer;
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  min-width: 75px;
+  text-align: center;
+}
+
+.win-button:active {
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 10px 3px;
+}
+
+.win-button-primary {
+  background: var(--color-win-gray-light);
+  outline: 1px solid var(--color-win-black);
+  outline-offset: -1px;
+}
+
+.win-link {
+  color: var(--color-win-link);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.win-link:visited {
+  color: var(--color-win-visited);
+}
+
+.win-separator-h {
+  height: 0;
+  border: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 4px 0;
+}
+
+.win-separator-v {
+  width: 0;
+  border: 0;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #ffffff;
+  align-self: stretch;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 4px;
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.win-inset-field {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 6px;
+  font-family: "Tahoma", "MS Sans Serif", "Arial", sans-serif;
+  font-size: 11px;
+  color: var(--color-win-black);
+  border: 0;
+  outline: none;
+  width: 100%;
+}
+
+@keyframes win-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+@keyframes marquee-scroll {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(-100%); }
 }
 
 /* Utilities */
@@ -162,6 +353,7 @@ body {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-areas: "c c c c";
+  background: var(--color-win-gray-light);
 }
 
 @media (min-width: 700px) {

--- a/app/components/app/footer.vue
+++ b/app/components/app/footer.vue
@@ -19,209 +19,365 @@ const servicesLinks = [
 </script>
 
 <template>
-  <footer class="relative" aria-label="Site footer">
-    <svg
-      class="absolute w-dvw -bottom-1/6 mix-blend-overlay opacity-10"
-      viewBox="0 0 301 53"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g clip-path="url(#clip0_1378_1054)">
-        <path
-          d="M71.0386 36.6707C71.3253 37.0288 71.6121 37.3153 71.8271 37.5302C71.6837 28.3622 71.4687 19.1941 71.3253 9.88281H77.5618V43.1886H70.7519C62.2215 33.8773 52.5442 25.2823 44.5156 15.0398V43.1886H38.6376V9.95444C41.0031 9.95444 43.3687 9.95444 45.7342 9.95444C45.9493 9.95444 46.1643 10.1693 46.3077 10.3126"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M241.287 26.5721C241.287 30.9412 240.069 34.9522 236.986 38.1754C231.61 43.6905 224.012 43.1175 219.352 36.9577C215.123 31.2277 215.051 22.2029 219.281 16.4729C221.503 13.4646 224.298 11.4591 228.098 11.3159C232.829 11.101 236.27 13.5363 238.707 17.3324C240.499 20.1258 241.359 23.2773 241.287 26.6437"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M261.215 38.3184V43.3322C260.212 43.9052 259.208 44.4782 258.205 44.9796C251.61 48.4892 244.728 51.211 237.273 52.2138C229.245 53.2165 221.861 51.6408 215.051 47.2716C208.671 43.1173 205.446 37.0292 204.8 29.5801C204.227 23.5636 205.23 17.762 207.094 12.1036C207.166 11.8887 207.309 11.6738 207.453 11.3873C212.04 9.38179 216.843 7.87766 221.933 7.51953C210.248 13.6793 208.17 31.0127 216.126 41.2551C219.782 45.9824 224.872 47.8446 230.678 47.9879C241.431 48.2027 250.893 45.0512 259.997 39.1063"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M196.7 14.8966V9.59627C199.209 8.30702 201.861 6.87451 204.657 5.65688C211.395 2.64861 218.349 0.49985 225.875 0.786352C234.047 1.14448 241.359 3.79462 247.022 9.9544C250.463 13.6789 252.112 18.1913 252.685 23.2051C253.402 29.2933 252.327 35.2382 250.463 41.0398C250.32 41.4696 250.033 41.9709 249.674 42.1142C245.445 44.0481 241.001 45.2657 236.413 45.8387C236.27 45.8387 236.198 45.8387 235.839 45.7671C238.635 44.1913 240.786 42.1858 242.434 39.6789C248.456 30.6541 247.094 16.9737 239.424 10.026C236.126 7.01776 232.112 5.7285 227.811 5.51363C218.707 5.08388 210.248 7.37589 202.291 11.745C200.499 12.7478 198.779 13.8222 196.844 15.0398"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M0.286736 9.88281H28.2434V13.3208H7.025V24.1363H27.0248V27.5743H7.025V39.7506H29.462V43.2602H0.286736V9.88281Z"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M84.0133 9.9541H91.3251C95.9129 19.5519 100.501 29.2213 105.017 38.5326C109.891 29.2213 114.837 19.6235 119.855 10.0257H127.024C120.787 21.1993 114.694 32.2296 108.529 43.3315H101.074C95.4827 32.3012 89.8197 21.2709 84.085 10.0257"
-          fill="#FAFAFA"
-        />
-        <path d="M139.497 9.9541H132.973V43.2599H139.497V9.9541Z" fill="#FAFAFA" />
-        <path
-          d="M196.198 9.88281C193.904 10.9572 194.478 10.4558 192.112 11.9599C190.32 13.2492 190.75 12.8911 189.675 13.7506C184.227 18.1197 173.761 26.4283 173.761 26.4283L190.894 40.6101L202.722 46.7698C203.868 47.3428 205.087 47.7726 206.306 48.274C202.937 45.9103 199.639 43.69 196.127 41.3979C196.127 30.869 196.127 20.3401 196.127 9.88281M189.747 35.9544C187.166 33.161 185.016 30.5109 183.654 26.858C185.159 24.4227 187.883 21.9159 189.818 20.1252L189.675 35.9544H189.747Z"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M172.543 26.0702C170.679 25.5688 167.095 24.4944 164.944 23.8498C162.794 23.1335 160.643 22.4889 158.708 21.3429C155.912 19.7671 155.84 16.6872 158.493 14.7534C160.285 13.3925 162.507 12.9627 164.658 12.8911C168.6 12.6762 172.543 12.8911 176.342 14.3236C176.987 13.1776 177.489 12.1032 178.134 10.9572C177.847 10.8856 177.776 10.814 177.632 10.7423C172.399 9.23822 167.023 8.88009 161.647 9.66797C158.063 10.241 154.622 11.2437 151.898 13.8939C149.389 16.3291 149.317 20.1969 151.826 22.6322C154.192 24.9958 157.274 25.9985 160.357 27.0013C163.439 27.9324 166.593 28.7203 169.604 29.7947C171.539 30.4393 173.26 31.6569 173.546 33.949C173.833 36.3126 172.614 38.0316 170.034 39.106C166.02 40.7534 161.79 40.6817 157.633 40.0371C155.267 39.679 152.973 39.0344 150.536 38.4613C150.034 39.4641 149.532 40.5385 148.959 41.6845C149.174 41.7561 149.246 41.8994 149.389 41.8994C152.4 42.4724 155.339 43.3319 158.349 43.6184C163.869 44.1914 169.317 43.9765 174.478 41.6129C177.919 40.0371 180.5 37.7451 180.213 33.5192C180.213 33.4476 179.855 28.7203 172.543 26.0702Z"
-          fill="#FAFAFA"
-        />
-        <path d="M196.27 9.88281H189.675V43.4035H196.27V9.88281Z" fill="#FAFAFA" />
-        <path
-          d="M273.402 15.1113C272.47 14.6099 261.932 9.66773 260.929 9.23798C257.631 7.73385 254.334 6.22972 251.036 4.72559C251.18 4.86884 251.251 5.01209 251.395 5.08371C254.549 7.16085 258.778 10.0259 261.932 12.1746C262.434 12.5327 263.653 15.3261 264.083 16.0424C267.739 22.4887 268.527 26.1416 265.803 32.946C264.8 35.3812 261.789 40.6099 261.789 43.1884H268.025V39.3206C272.398 35.9542 276.556 32.7311 280.785 29.5079L273.473 15.1113H273.402ZM267.954 32.8027V17.7614C270.534 20.3399 272.685 23.1333 274.047 26.5713C272.04 28.5768 270.176 30.5107 267.954 32.8027Z"
-          fill="#FAFAFA"
-        />
-        <path
-          d="M294.19 36.742C294.477 37.1001 294.763 37.3866 294.978 37.6015C294.835 28.4334 294.62 19.2654 294.477 9.9541C296.699 9.9541 298.849 9.9541 300.928 9.9541C300.928 21.056 300.928 32.0863 300.928 43.2599C298.706 43.2599 296.269 43.2599 293.831 43.2599C285.301 33.9486 275.911 25.3536 267.882 15.0395C267.882 24.4224 267.882 33.7337 267.882 43.1883C266.018 43.1883 263.724 43.1883 261.646 43.1883V9.9541C264.011 9.9541 266.377 9.9541 268.742 9.9541C268.957 9.9541 269.172 10.169 269.316 10.3122"
-          fill="#FAFAFA"
-        />
-      </g>
-      <defs>
-        <clipPath id="clip0_1378_1054">
-          <rect width="301" height="52" fill="white" transform="translate(0 0.5)" />
-        </clipPath>
-      </defs>
-    </svg>
-    <div class="footer-head">
-      <NuxtLink class="brand-link" to="/" aria-label="Envision home">
-        <Icon name="logos:envision" size="30" alt="envision construction logo" />
-      </NuxtLink>
-    </div>
-    <section class="site-footer">
-      <div class="navigation">
-        <nav aria-label="Footer navigation">
-          <h3>Navigate</h3>
-          <ul>
-            <li v-for="link in navLinks" :key="link.id" class="footer-link">
-              <NuxtLink :to="link.to">
-                {{ link.label }}
-              </NuxtLink>
-            </li>
-          </ul>
-        </nav>
-        <nav>
-          <h3>Services</h3>
-          <ul>
-            <li v-for="link in servicesLinks" :key="link.id" class="footer-link">
-              <NuxtLink :to="link.to">
-                {{ link.label }}
-              </NuxtLink>
-            </li>
-          </ul>
-        </nav>
+  <footer class="footer-win" aria-label="Site footer">
+    <!-- Footer window -->
+    <div class="footer-win-window">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" style="display:inline-block;vertical-align:middle;margin-right:4px">
+            <rect width="14" height="14" fill="#1084d0"/>
+            <text x="2" y="11" font-size="9" fill="white" font-weight="bold">E</text>
+          </svg>
+          Envision Construction Services
+        </span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
+        </div>
       </div>
-      <div class="location-contact">
-        <div class="locations-container">
-          <h3>Locations</h3>
-          <div class="location-wrapper">
-            <div>
-              <h4>Tampa Office</h4>
-              <p class="max-w-sm">
-                5000 Acline Drive East Tampa, FL 33619 Po Box 89098 Tampa, FL 33689
-              </p>
-              <p>(813) 997-0330</p>
+
+      <!-- Footer body -->
+      <div class="footer-win-body">
+        <!-- Navigation panel -->
+        <div class="footer-win-panel footer-nav-panel">
+          <div class="footer-panel-title">Navigate</div>
+          <div class="footer-panel-body">
+            <nav aria-label="Footer navigation">
+              <ul class="footer-win-links">
+                <li v-for="link in navLinks" :key="link.id">
+                  <NuxtLink :to="link.to" class="footer-win-link">
+                    <span aria-hidden="true">&#128196;</span> {{ link.label }}
+                  </NuxtLink>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+
+        <!-- Services panel -->
+        <div class="footer-win-panel footer-services-panel">
+          <div class="footer-panel-title">Services</div>
+          <div class="footer-panel-body">
+            <nav>
+              <ul class="footer-win-links">
+                <li v-for="link in servicesLinks" :key="link.id">
+                  <NuxtLink :to="link.to" class="footer-win-link">
+                    <span aria-hidden="true">&#128196;</span> {{ link.label }}
+                  </NuxtLink>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+
+        <!-- Locations panel -->
+        <div class="footer-win-panel footer-locations-panel">
+          <div class="footer-panel-title">Locations</div>
+          <div class="footer-panel-body footer-locations-body">
+            <div class="footer-location">
+              <div class="footer-location-title">
+                <span aria-hidden="true">&#127968;</span> Tampa Office
+              </div>
+              <p class="footer-location-addr">5000 Acline Drive East<br>Tampa, FL 33619<br>Po Box 89098 Tampa, FL 33689</p>
+              <p class="footer-location-phone">(813) 997-0330</p>
             </div>
-            <div>
-              <h4>Pasco Office</h4>
-              <p class="max-w-sm">
-                5000 Acline Drive East Tampa, FL 33619 Po Box 89098 Tampa FL 33689
-              </p>
+            <hr class="footer-divider">
+            <div class="footer-location">
+              <div class="footer-location-title">
+                <span aria-hidden="true">&#127968;</span> Pasco Office
+              </div>
+              <p class="footer-location-addr">5000 Acline Drive East<br>Tampa, FL 33619<br>Po Box 89098 Tampa FL 33689</p>
             </div>
           </div>
         </div>
-        <div class="contact">
-          <h3>Start the conversation</h3>
-          <p class="max-w-sm">
-            From preconstruction through closeout, our process stays direct: listen, plan, execute,
-            cultivate.
-          </p>
-          <NuxtLink>Contact Us</NuxtLink>
+
+        <!-- Contact panel -->
+        <div class="footer-win-panel footer-contact-panel">
+          <div class="footer-panel-title">Start the Conversation</div>
+          <div class="footer-panel-body">
+            <p class="footer-contact-text">
+              From preconstruction through closeout, our process stays direct: listen, plan, execute, cultivate.
+            </p>
+            <div class="footer-win-sep" />
+            <NuxtLink to="/contact" class="win-button win-button-primary">Contact Us</NuxtLink>
+            <div class="footer-win-sep" />
+            <div class="footer-social-row">
+              <NuxtLink to="https://www.facebook.com/envisioncstampa" class="footer-social-btn" aria-label="Facebook">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+              </NuxtLink>
+              <NuxtLink to="https://www.linkedin.com/company/envision-cs/" class="footer-social-btn" aria-label="LinkedIn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+              </NuxtLink>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="date-socials">
-        <div>
-          <NuxtLink class="mr-2 mb-0" to="https://www.facebook.com/envisioncstampa">
-            <Icon name="ri:facebook-box-fill" size="32" />
-          </NuxtLink>
-          <NuxtLink class="mb-0" to="https://www.linkedin.com/company/envision-cs/">
-            <Icon name="ri:linkedin-box-fill" size="32" />
-          </NuxtLink>
+
+      <!-- Bottom status bar -->
+      <div class="footer-win-bottom">
+        <div class="win-status-bar">
+          <span>&#9679;</span>
+          <span>&copy;{{ year }} Envision Construction Services. All rights reserved.</span>
+          <div class="footer-bottom-sep" />
+          <span>Tampa, FL</span>
+          <div class="footer-bottom-sep" />
+          <a href="/privacy" class="footer-bottom-link">Privacy Policy</a>
         </div>
-        <p>©{{ year }}Envision Construction. All rights reserved.</p>
       </div>
-    </section>
+    </div>
   </footer>
 </template>
 
 <style scoped>
-footer {
-  background-color: var(--color-envision-blue-900);
-  padding: calc(var(--spacing) * 4);
-  color: var(--color-envision-blue-50);
-  overflow: hidden;
+.footer-win {
+  background: var(--color-win-gray-light);
+  padding: 16px 16px 8px;
+  border-top: 2px solid #808080;
+  box-shadow: inset 0 2px 0 #ffffff;
 }
 
-.footer-head {
-  margin-inline: auto;
-  max-width: 1200px;
-  margin-top: calc(var(--spacing));
-  margin-bottom: calc(var(--spacing) * 4);
+.footer-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
-.site-footer {
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.footer-win-body {
   display: grid;
-  margin-inline: auto;
-  max-width: 1200px;
-  grid-template-areas:
-    "a"
-    "b"
-    "c";
+  grid-template-columns: 1fr;
+  gap: 8px;
+  padding: 8px;
 
-  @media (min-width: 768px) {
-    grid-template-areas:
-      "a b"
-      "c c";
-    gap: calc(var(--spacing) * 8);
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1000px) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
-h3 {
-  font-size: var(--text-lg);
-  letter-spacing: 2%;
-  font-weight: 600;
-  margin-bottom: calc(var(--spacing) * 2);
+.footer-win-panel {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  display: flex;
+  flex-direction: column;
 }
 
-.footer-link {
-  color: var(--color-envision-blue-200);
-  font-size: var(--text-base);
-  opacity: 1;
-  transition: opacity 300ms ease-in-out;
+.footer-panel-title {
+  background: linear-gradient(to right, #000080 0%, #404080 100%);
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.footer-panel-body {
+  padding: 8px;
+  flex: 1;
+}
+
+.footer-win-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.footer-win-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-link);
+  text-decoration: underline;
+  padding: 1px 2px;
+}
+
+.footer-win-link:hover {
+  background: var(--color-win-highlight);
+  color: var(--color-win-highlight-text);
+  text-decoration: none;
+}
+
+.footer-locations-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.footer-location {}
+
+.footer-location-title {
+  font-size: 11px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  margin-bottom: 3px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.footer-location-addr {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.footer-location-phone {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  margin: 2px 0 0;
+}
+
+.footer-divider {
+  height: 0;
+  border: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 4px 0;
+}
+
+.footer-contact-text {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  line-height: 1.45;
+  margin: 0 0 8px;
+}
+
+.footer-win-sep {
+  height: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 8px 0;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", sans-serif;
+  font-size: 11px;
+  padding: 3px 14px 4px;
   cursor: pointer;
-  margin-bottom: calc(var(--spacing));
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  min-width: 75px;
+  text-align: center;
 }
 
-.navigation:has(a:hover) a:not(:hover) {
-  opacity: 0.4;
+.win-button:active {
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 14px 3px;
 }
 
-.navigation {
-  grid-area: a;
+.win-button-primary {
+  outline: 1px solid #000;
+  outline-offset: -1px;
+}
+
+.footer-social-row {
   display: flex;
-  flex-wrap: wrap;
-  gap: calc(var(--spacing) * 6);
+  gap: 4px;
 }
 
-.location-contact {
-  grid-area: b;
-  display: grid;
-  gap: calc(var(--spacing) * 4);
-}
-
-.location-wrapper {
+.footer-social-btn {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  width: 28px;
+  height: 26px;
   display: flex;
-  flex-wrap: wrap;
-  gap: calc(var(--spacing) * 3);
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
 }
 
-.date-socials {
-  grid-area: c;
+.footer-social-btn:active {
+  box-shadow: var(--win-border-sunken);
+}
+
+.footer-win-bottom {
+  border-top: 2px solid #808080;
+  box-shadow: inset 0 2px 0 #ffffff;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
   display: flex;
+  align-items: center;
+  gap: 6px;
   flex-wrap: wrap;
-  justify-content: space-between;
+}
+
+.footer-bottom-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
+}
+
+.footer-bottom-link {
+  color: var(--color-win-link);
+  text-decoration: underline;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+}
+
+.footer-bottom-link:hover {
+  color: var(--color-win-navy);
 }
 </style>

--- a/app/components/app/header.vue
+++ b/app/components/app/header.vue
@@ -293,8 +293,476 @@ function toggleDesktopMenu(menu: "services" | "projects") {
 
 <style>
 .main-header {
-  --header-height: 3.5rem;
-  --header-shell-bg: color-mix(in oklch, black 20%, var(--color-envision-blue-50) 3%);
+  --header-height: 26px;
+  --header-shell-bg: var(--color-win-gray-light);
+  --header-shell-text: var(--color-win-black);
+  --header-panel-bg: var(--color-win-gray-light);
+
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  color: var(--header-shell-text);
+  background: var(--color-win-gray-light);
+  border-bottom: 2px solid #808080;
+  box-shadow: 0 2px 0 #ffffff;
+  animation: none;
+}
+
+.header-root {
+  inset-inline: 0;
+  display: flex;
+  align-items: center;
+  margin-inline: auto;
+  gap: 0;
+  padding: 2px 4px;
+  min-height: var(--header-height);
+  position: relative;
+  z-index: 2;
+  max-width: 100%;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  padding: 2px 8px 2px 4px;
+  margin-right: 4px;
+  border-right: 1px solid #808080;
+  text-decoration: none;
+  color: var(--color-win-black);
+  font-size: 11px;
+  font-weight: bold;
+  gap: 4px;
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+}
+
+.desktop-mega-menu-backdrop {
+  display: none;
+}
+
+.desktop-nav {
+  display: none;
+  min-width: 0;
+}
+
+.header-cta {
+  flex-shrink: 0;
+}
+
+.header-cta.header-cta--mobile-hidden {
+  display: none !important;
+}
+
+@media (min-width: 768px) {
+  .header-cta.header-cta--mobile-hidden {
+    display: flex !important;
+    align-items: center;
+    margin-left: auto;
+  }
+
+  .header-cta.header-cta--mobile-hidden a,
+  .header-cta.header-cta--mobile-hidden button {
+    background: var(--color-win-gray-light) !important;
+    box-shadow: var(--win-border-button) !important;
+    color: var(--color-win-black) !important;
+    font-family: "Tahoma", "MS Sans Serif", sans-serif !important;
+    font-size: 11px !important;
+    padding: 3px 10px 4px !important;
+    border-radius: 0 !important;
+    text-decoration: none !important;
+    border: 0 !important;
+    outline: 1px solid #000 !important;
+    outline-offset: -1px !important;
+    font-weight: normal !important;
+    letter-spacing: 0 !important;
+    text-transform: none !important;
+    min-width: 75px !important;
+    text-align: center !important;
+    display: inline-block !important;
+  }
+
+  .header-cta.header-cta--mobile-hidden a:active,
+  .header-cta.header-cta--mobile-hidden button:active {
+    box-shadow: var(--win-border-sunken) !important;
+    padding: 4px 10px 3px !important;
+  }
+
+  .desktop-nav {
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .NavigationMenuRoot {
+    position: relative;
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+    z-index: 1;
+    align-items: center;
+  }
+
+  .NavigationMenuList {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    color: inherit;
+    gap: 0;
+    padding: 0;
+    min-height: var(--header-height);
+    border-radius: 0;
+    list-style: none;
+    margin: 0;
+    width: 100%;
+  }
+
+  .NavigationMenuList > :last-child {
+    margin-left: auto;
+  }
+
+  .NavigationMenuTrigger {
+    background: transparent;
+    cursor: pointer;
+    position: relative;
+    z-index: 3;
+  }
+
+  .desktop-inline-nav-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    min-height: 22px;
+    padding: 2px 8px 3px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--color-win-black);
+    text-decoration: none;
+    white-space: nowrap;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 11px;
+    font-family: "Tahoma", "MS Sans Serif", sans-serif;
+    font-weight: normal;
+    transition: none;
+  }
+
+  .desktop-inline-nav-link::after {
+    display: none;
+  }
+
+  .desktop-inline-nav-link:hover,
+  .desktop-inline-nav-link:focus-visible {
+    background: var(--color-win-highlight);
+    color: var(--color-win-highlight-text);
+    outline: none;
+  }
+
+  .desktop-inline-nav-link[aria-expanded="true"] {
+    background: var(--color-win-highlight);
+    color: var(--color-win-highlight-text);
+    outline: none;
+  }
+
+  .desktop-mega-menu-backdrop {
+    display: block;
+    position: fixed;
+    inset: var(--header-height) 0 0;
+    border: 0;
+    background: transparent;
+    z-index: 1;
+  }
+
+  .NavigationMenuContent {
+    width: auto;
+    animation-duration: 0ms;
+  }
+
+  .NavigationMenuContent[data-motion="from-start"],
+  .NavigationMenuContent[data-motion="from-end"],
+  .NavigationMenuContent[data-motion="to-start"],
+  .NavigationMenuContent[data-motion="to-end"] {
+    animation-name: none;
+  }
+
+  .ViewportPosition {
+    position: fixed;
+    display: flex;
+    justify-content: flex-start;
+    width: auto;
+    min-width: 200px;
+    top: calc(var(--header-height) + 6px);
+    left: 60px;
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  .NavigationMenuViewport {
+    position: relative;
+    transform-origin: top left;
+    margin-top: 0;
+    width: auto;
+    background: var(--color-win-gray-light);
+    border-radius: 0;
+    overflow: auto;
+    height: var(--reka-navigation-menu-viewport-height);
+    transition: none;
+    pointer-events: auto;
+    box-shadow:
+      inset -1px -1px 0 #404040,
+      inset 1px 1px 0 #ffffff,
+      inset -2px -2px 0 #808080,
+      inset 2px 2px 0 #d4d0c8,
+      4px 4px 0 rgba(0,0,0,0.3);
+  }
+
+  .mega-menu-grid {
+    display: grid;
+    grid-template-columns: minmax(200px, 0.6fr) minmax(0, 1.4fr);
+    min-height: 200px;
+    margin: 0 auto;
+    max-width: 800px;
+  }
+
+  .services-feature-panel {
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    overflow: hidden;
+    min-height: 200px;
+    padding: 12px;
+    color: white;
+    text-decoration: none;
+    isolation: isolate;
+    background: var(--color-win-navy);
+  }
+
+  .services-feature-panel--projects {
+    background: var(--color-win-teal-dark);
+  }
+
+  .services-feature-panel__image,
+  .services-feature-panel__overlay,
+  .services-feature-panel__grid {
+    position: absolute;
+    inset: 0;
+  }
+
+  .services-feature-panel__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.4;
+    filter: grayscale(1);
+    z-index: -2;
+  }
+
+  .services-feature-panel__overlay {
+    background: var(--color-win-navy);
+    mix-blend-mode: multiply;
+    z-index: -1;
+  }
+
+  .services-feature-panel--projects .services-feature-panel__overlay {
+    background: var(--color-win-teal-dark);
+  }
+
+  .services-feature-panel__grid {
+    background:
+      linear-gradient(rgb(255 255 255 / 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgb(255 255 255 / 0.08) 1px, transparent 1px);
+    background-size: 16px 16px;
+    z-index: -1;
+  }
+
+  .services-feature-panel__content {
+    display: grid;
+    gap: 6px;
+    width: min(180px, 100%);
+    align-content: end;
+  }
+
+  .services-feature-panel__eyebrow {
+    font-size: 10px;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgb(255 255 255 / 0.8);
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-feature-panel__title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: bold;
+    line-height: 1;
+    letter-spacing: 0;
+    text-transform: none;
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-feature-panel__copy {
+    margin: 0;
+    max-width: 160px;
+    font-size: 10px;
+    line-height: 1.4;
+    color: rgb(255 255 255 / 0.75);
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-feature-panel__rule {
+    width: 60px;
+    height: 1px;
+    background: rgb(255 255 255 / 0.5);
+  }
+
+  .services-feature-panel__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: bold;
+    line-height: 1.2;
+    letter-spacing: 0.05em;
+    text-transform: none;
+    font-family: "Tahoma", sans-serif;
+    color: #aad4ff;
+    text-decoration: underline;
+  }
+
+  .services-feature-panel__link::after {
+    display: none;
+  }
+
+  .services-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    min-height: 200px;
+    color: var(--color-win-black);
+    background: var(--color-win-white);
+    border-left: 2px solid #808080;
+  }
+
+  .services-grid-item {
+    display: grid;
+    align-content: start;
+    gap: 4px;
+    padding: 10px 12px;
+    color: inherit;
+    text-decoration: none;
+    border-left: 1px solid #d4d0c8;
+    border-top: 1px solid #d4d0c8;
+    transition: none;
+  }
+
+  .services-grid-item:nth-child(-n + 3) {
+    border-top: 0;
+  }
+
+  .services-grid-item__index {
+    font-size: 9px;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-win-navy);
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-grid-item__title {
+    margin: 0;
+    font-size: 12px;
+    font-weight: bold;
+    line-height: 1.2;
+    letter-spacing: 0;
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-grid-item__description {
+    margin: 0;
+    max-width: 20ch;
+    font-size: 10px;
+    color: #404040;
+    line-height: 1.35;
+    font-family: "Tahoma", sans-serif;
+  }
+
+  .services-grid-item:hover,
+  .services-grid-item:focus-visible {
+    background-color: var(--color-win-highlight);
+    color: var(--color-win-highlight-text);
+    outline: none;
+  }
+
+  .services-grid-item:hover .services-grid-item__title,
+  .services-grid-item:focus-visible .services-grid-item__title,
+  .services-grid-item:hover .services-grid-item__index,
+  .services-grid-item:focus-visible .services-grid-item__index,
+  .services-grid-item:hover .services-grid-item__description,
+  .services-grid-item:focus-visible .services-grid-item__description {
+    color: var(--color-win-highlight-text);
+  }
+}
+
+@media (max-width: 767px) {
+  .header-root::before,
+  .header-root::after {
+    display: none;
+  }
+}
+
+@keyframes enterFromTop {
+  from { opacity: 1; transform: none; }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes enterFromRight {
+  from { opacity: 1; transform: none; }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes enterFromLeft {
+  from { opacity: 1; transform: none; }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes exitToRight {
+  from { opacity: 1; transform: none; }
+  to { opacity: 0; transform: none; }
+}
+
+@keyframes exitToLeft {
+  from { opacity: 1; transform: none; }
+  to { opacity: 0; transform: none; }
+}
+
+.submenu-label {
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .main-header {
+    animation: none !important;
+  }
+}
+</style>
   --header-shell-border: color-mix(in oklch, var(--color-envision-blue-900) 18%, white);
   --header-shell-text: color-mix(
     in oklch,

--- a/app/components/app/mobile-nav-drawer.vue
+++ b/app/components/app/mobile-nav-drawer.vue
@@ -258,9 +258,166 @@ function onDrawerCloseAutoFocus(event: Event) {
 .mobile-overlay {
   position: fixed;
   inset: 0;
-  background: rgb(15 31 52 / 14%);
+  background: rgba(0, 0, 0, 0.5);
   z-index: 200;
 }
+
+.mobile-content {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100dvh;
+  width: min(280px, 92vw);
+  margin: 0;
+  border-left: 2px solid #808080;
+  box-shadow: -4px 0 0 #ffffff;
+  background: var(--color-win-gray-light);
+  color: var(--color-win-black);
+  z-index: 201;
+  overflow-y: auto;
+  padding: 0;
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+}
+
+.mobile-content-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: var(--win-titlebar);
+  padding: 3px 4px 3px 6px;
+  color: #fff;
+}
+
+.mobile-brand-block {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mobile-brand-block__eyebrow {
+  font-size: 11px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: #fff;
+}
+
+.mobile-brand-block__mark {
+  display: none;
+}
+
+.mobile-nav-close {
+  flex: 0 0 auto;
+}
+
+.mobile-nav-close :deep(*) {
+  background: var(--color-win-gray-light) !important;
+  box-shadow: var(--win-border-button) !important;
+  color: var(--color-win-black) !important;
+  font-family: "Tahoma", sans-serif !important;
+  font-size: 10px !important;
+  padding: 2px 10px 3px !important;
+  border-radius: 0 !important;
+  border: 0 !important;
+  font-weight: normal !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+.mobile-nav {
+  padding: 4px;
+}
+
+.mobile-nav-list,
+.mobile-services-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+}
+
+.mobile-nav-list__item,
+.mobile-services-list__item {
+  border-bottom: 1px solid #d4d0c8;
+  box-shadow: 0 1px 0 #ffffff;
+}
+
+.mobile-link,
+.mobile-services-toggle {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 28px;
+  font-size: 11px;
+  text-decoration: none;
+  color: var(--color-win-black);
+  background: var(--color-win-gray-light);
+  transition: none;
+  padding: 4px 8px;
+}
+
+.mobile-link__label,
+.mobile-services-toggle__label {
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  font-family: "Tahoma", sans-serif;
+}
+
+.mobile-link--accent {
+  background: var(--color-win-navy);
+  color: #fff;
+  font-weight: bold;
+}
+
+.mobile-services-toggle {
+  width: 100%;
+  border: 0;
+  background: var(--color-win-gray-light);
+  text-align: left;
+  cursor: pointer;
+}
+
+.mobile-link:hover,
+.mobile-link:focus-visible,
+.mobile-services-toggle:hover,
+.mobile-services-toggle:focus-visible {
+  background: var(--color-win-highlight);
+  color: var(--color-win-highlight-text);
+  outline: none;
+}
+
+.mobile-link--accent:hover,
+.mobile-link--accent:focus-visible {
+  background: var(--color-win-highlight);
+}
+
+.mobile-services-panel {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  margin: 4px;
+}
+
+.mobile-services-list {
+  padding-left: 0;
+}
+
+.mobile-services-list .mobile-link {
+  min-height: 24px;
+  padding: 3px 12px;
+  font-size: 11px;
+}
+
+@media (min-width: 768px) {
+  .mobile-trigger,
+  .mobile-overlay,
+  .mobile-content {
+    display: none;
+  }
+}
+</style>
 
 .mobile-content {
   position: fixed;

--- a/app/components/card-group-a.vue
+++ b/app/components/card-group-a.vue
@@ -16,63 +16,338 @@ const visibleCards = computed(() => props.cards.slice(0, 3));
 </script>
 
 <template>
-  <section class="card-group-a">
-    <div class="main-wrapper site-grid">
-      <ul class="wrapper">
-        <li v-for="(card, index) in visibleCards" :key="index">
-          <app-reveal-card
-            :image="card.image"
-            :title="card.title"
-            :to="card.link"
-            aspect-ratio="3/4"
-            :title-offset="-16"
-            :image-hover-blur="0"
-          >
-            <template #title>
-              <app-typography class="" variant="heading-md">
-                {{ card.title }}
-              </app-typography>
-            </template>
-            <template #meta>
-              <div class="flex gap-2 items-center">
-                <p>See Project</p>
-                <UIcon name="i-lucide-arrow-right" />
+  <section class="cards-win-section">
+    <div class="cards-win-window">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>Featured Projects</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
+        </div>
+      </div>
+
+      <!-- Toolbar row -->
+      <div class="cards-win-toolbar">
+        <span class="cards-win-toolbar-label">View:</span>
+        <button class="cards-toolbar-btn cards-toolbar-btn--active">Large Icons</button>
+        <button class="cards-toolbar-btn">Details</button>
+        <button class="cards-toolbar-btn">List</button>
+        <div class="cards-toolbar-spacer" />
+        <NuxtLink to="/projects" class="win-button win-button-small">View All Projects</NuxtLink>
+      </div>
+
+      <!-- File/folder grid -->
+      <div class="cards-win-body">
+        <ul v-if="visibleCards.length" class="cards-win-grid">
+          <li v-for="(card, index) in visibleCards" :key="index" class="card-win-item">
+            <NuxtLink :to="card.link" class="card-win-link">
+              <div class="card-win-image-wrap">
+                <NuxtImg
+                  :src="card.image"
+                  provider="imagekit"
+                  format="webp"
+                  loading="lazy"
+                  fit="cover"
+                  class="card-win-img"
+                  :alt="card.title"
+                />
               </div>
-            </template>
-          </app-reveal-card>
-        </li>
-      </ul>
+              <div class="card-win-info">
+                <div class="win-titlebar win-titlebar--mini" role="presentation">
+                  <span>{{ card.title }}</span>
+                  <div class="win-titlebar-buttons" aria-hidden="true">
+                    <button class="win-titlebar-btn win-titlebar-btn--tiny" tabindex="-1">&#x2715;</button>
+                  </div>
+                </div>
+                <div class="card-win-meta">
+                  <div class="card-win-row"><span class="card-win-key">Sector:</span> <span>{{ card.sector }}</span></div>
+                  <div class="card-win-row"><span class="card-win-key">Completed:</span> <span>{{ card.completed }}</span></div>
+                  <div class="card-win-row"><span class="card-win-key">Status:</span> <span class="card-win-completed">&#9679; Completed</span></div>
+                </div>
+                <div class="card-win-actions">
+                  <span class="win-button win-button-small">See Project</span>
+                </div>
+              </div>
+            </NuxtLink>
+          </li>
+        </ul>
+        <div v-else class="cards-win-empty">
+          <span>No items to display.</span>
+        </div>
+      </div>
+
+      <div class="win-status-bar cards-win-status">
+        <span>&#9679;</span>
+        <span>{{ visibleCards.length }} object(s)</span>
+        <div class="cards-sep" />
+        <span>Double-click a project to open</span>
+      </div>
     </div>
   </section>
 </template>
 
 <style scoped>
-section {
-  grid-column: 1/-1;
+.cards-win-section {
+  grid-column: 1 / -1;
+  background: var(--color-win-gray-light);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
 }
 
-.main-wrapper {
-  container-type: inline-size;
-  gap: calc(var(--spacing) * 8);
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 16);
+.cards-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 1100px;
+  display: flex;
+  flex-direction: column;
 }
 
-.wrapper {
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.win-titlebar--mini {
+  font-size: 10px;
+  padding: 2px 4px;
+}
+
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.win-titlebar-btn--tiny {
+  width: 12px;
+  height: 11px;
+  font-size: 8px;
+}
+
+.cards-win-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--color-win-gray-light);
+  padding: 4px 8px;
+  border-bottom: 2px solid #808080;
+  box-shadow: 0 2px 0 #ffffff;
+  flex-wrap: wrap;
+}
+
+.cards-win-toolbar-label {
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  margin-right: 4px;
+}
+
+.cards-toolbar-btn {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  padding: 2px 8px 3px;
+  cursor: pointer;
+  border: 0;
+}
+
+.cards-toolbar-btn--active {
+  box-shadow: var(--win-border-sunken);
+}
+
+.cards-toolbar-spacer {
+  flex: 1;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", sans-serif;
+  font-size: 11px;
+  padding: 3px 14px 4px;
+  cursor: pointer;
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  min-width: 75px;
+  text-align: center;
+}
+
+.win-button:active,
+.win-button-small:active {
+  box-shadow: var(--win-border-sunken);
+}
+
+.win-button-primary {
+  outline: 1px solid #000;
+  outline-offset: -1px;
+}
+
+.win-button-small {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", sans-serif;
+  font-size: 10px;
+  padding: 2px 10px 3px;
+  cursor: pointer;
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.cards-win-body {
+  padding: 8px;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  margin: 8px;
+  min-height: 200px;
+}
+
+.cards-win-grid {
   display: grid;
-  gap: calc(var(--spacing) * 4);
-  grid-column: 1/-1;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
-  @container (inline-size < 40ch) {
-    grid-template-columns: repeat(1, 1fr);
-  }
-
-  @container (inline-size > calc(35ch * 2 + 1rem)) {
+  @media (min-width: 600px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @container (inline-size > calc(40ch * 3 + 1rem)) {
+  @media (min-width: 900px) {
     grid-template-columns: repeat(3, 1fr);
   }
+}
+
+.card-win-item {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+}
+
+.card-win-link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--color-win-black);
+  height: 100%;
+}
+
+.card-win-link:hover .card-win-image-wrap .card-win-img {
+  filter: saturate(0.6) brightness(0.85);
+}
+
+.card-win-image-wrap {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 4/3;
+}
+
+.card-win-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.6) contrast(0.85);
+  display: block;
+}
+
+.card-win-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.card-win-meta {
+  padding: 8px 10px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  margin: 6px 6px 0;
+  flex: 1;
+}
+
+.card-win-row {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  line-height: 1.4;
+}
+
+.card-win-key {
+  font-weight: bold;
+  color: #404040;
+}
+
+.card-win-completed {
+  color: var(--color-win-green);
+  font-weight: bold;
+  font-size: 10px;
+}
+
+.card-win-actions {
+  padding: 6px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cards-win-empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  color: #808080;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cards-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
 }
 </style>

--- a/app/components/company-stats.vue
+++ b/app/components/company-stats.vue
@@ -7,73 +7,153 @@ const stats = [
 ];
 </script>
 <template>
-  <section>
-    <ul>
-      <li v-for="stat in stats" :key="stat.id">
-        <div class="stat">
-          <app-typography tag="h4" variant="heading-xl">
-            {{ stat.value }}
-          </app-typography>
-          <app-typography tag="p" variant="text-lg">
-            {{ stat.label }}
-          </app-typography>
+  <section class="stats-win-section">
+    <!-- Window chrome -->
+    <div class="stats-win-window">
+      <div class="win-titlebar" role="presentation">
+        <span>Company Information</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
         </div>
-      </li>
-    </ul>
+      </div>
+      <div class="stats-win-body">
+        <ul class="stats-win-list">
+          <li v-for="stat in stats" :key="stat.id" class="stats-win-item">
+            <div class="stats-win-panel">
+              <span class="stats-win-value">{{ stat.value }}</span>
+              <span class="stats-win-label">{{ stat.label }}</span>
+            </div>
+          </li>
+        </ul>
+        <div class="win-status-bar stats-win-status">
+          <span>&#9679;</span>
+          <span>4 items loaded</span>
+          <div class="stats-sep" />
+          <span>Envision Construction Services, Tampa FL</span>
+        </div>
+      </div>
+    </div>
   </section>
 </template>
 <style scoped>
-section {
-  display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
-  gap: calc(var(--spacing) * 8);
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 16);
+.stats-win-section {
+  grid-column: 1 / -1;
+  background: var(--color-win-gray-light);
+  padding: 24px 16px;
+  display: flex;
+  justify-content: center;
 }
 
-ul {
-  display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
+.stats-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 960px;
+}
 
-  gap: calc(var(--spacing) * 8);
-
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
   align-items: center;
+  gap: 4px;
+  user-select: none;
 }
 
-li {
-  padding: calc(var(--spacing) * 3);
-  grid-column: span 2;
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
 
-  &:nth-child(even) {
-    border-left: 1px solid var(--ui-border);
-  }
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
 
-  &:last-child {
-    h4 {
-      font-size: 2.5rem;
-    }
-  }
+.stats-win-body {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
 
-  @media (min-width: 700px) {
-    grid-column: span 6;
+.stats-win-list {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
-    &:nth-child(even) {
-      border-left: 1px solid var(--ui-border);
-    }
-  }
-
-  @media (min-width: 1024px) {
-    grid-column: span 6;
-
-    &:not(:first-child) {
-      border-left: 1px solid var(--ui-border);
-    }
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
-.stat {
+.stats-win-item {
+  padding: 0;
+}
+
+.stats-win-panel {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 12px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   text-align: center;
+}
+
+.stats-win-value {
+  font-size: clamp(18px, 3vw, 28px);
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  line-height: 1;
+}
+
+.stats-win-label {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: #404040;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stats-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
 }
 </style>

--- a/app/components/cta-a.vue
+++ b/app/components/cta-a.vue
@@ -8,113 +8,245 @@ const props = defineProps<{
 </script>
 
 <template>
-  <section>
-    <div class="content" :class="{ 'is-flipped': props.flip }">
-      <app-typography tag="h2" variant="heading-lg" class="cta-panel__title">
-        <slot name="title">
-          <slot />
-        </slot>
-      </app-typography>
-
-      <app-typography tag="p" variant="text-xl" class="cta-panel__body">
-        {{ body }}
-        <slot name="body" />
-      </app-typography>
-
-      <div class="cta-panel__actions">
-        <template v-if="href">
-          <app-button :to="href" color="secondary" variant="solid">Learn More</app-button>
-        </template>
-        <slot name="action" />
+  <section class="cta-win-section">
+    <div class="cta-win-window" :class="{ 'is-flipped': props.flip }">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>
+          <slot name="title">
+            <slot />
+          </slot>
+        </span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
+        </div>
       </div>
-    </div>
-    <NuxtLink v-if="href" :to="href" class="image" :class="{ 'is-flipped': props.flip }">
-      <NuxtImg
-        :src="image"
-        provider="imagekit"
-        :modifiers="{ focus: 'bottom' }"
-        format="webp"
-        loading="lazy"
-        class="w-full h-full"
-        fit="cover"
-        placeholder
-      />
-    </NuxtLink>
-    <div v-else class="image" :class="{ 'is-flipped': props.flip }">
-      <NuxtImg
-        :src="image"
-        provider="imagekit"
-        :modifiers="{ focus: 'bottom' }"
-        format="webp"
-        loading="lazy"
-        class="w-full h-full"
-        fit="cover"
-        placeholder
-      />
+
+      <div class="cta-win-body">
+        <!-- Image pane -->
+        <NuxtLink v-if="href" :to="href" class="cta-win-image">
+          <NuxtImg
+            :src="image"
+            provider="imagekit"
+            :modifiers="{ focus: 'bottom' }"
+            format="webp"
+            loading="lazy"
+            class="cta-win-img"
+            fit="cover"
+            placeholder
+          />
+          <div class="cta-win-img-overlay" aria-hidden="true" />
+        </NuxtLink>
+        <div v-else class="cta-win-image">
+          <NuxtImg
+            :src="image"
+            provider="imagekit"
+            :modifiers="{ focus: 'bottom' }"
+            format="webp"
+            loading="lazy"
+            class="cta-win-img"
+            fit="cover"
+            placeholder
+          />
+          <div class="cta-win-img-overlay" aria-hidden="true" />
+        </div>
+
+        <!-- Text pane -->
+        <div class="cta-win-text">
+          <div class="cta-win-text-inner">
+            <p class="cta-win-body-text">{{ body }}</p>
+            <slot name="body" />
+            <div class="cta-win-separator" />
+            <div class="cta-win-actions">
+              <template v-if="href">
+                <NuxtLink :to="href" class="win-button win-button-primary">Learn More</NuxtLink>
+              </template>
+              <slot name="action" />
+            </div>
+          </div>
+          <div class="cta-win-status">
+            <span>&#9679;</span>
+            <span>Envision Construction Services</span>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </template>
 
 <style scoped>
-section {
-  display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
-  gap: calc(var(--spacing) * 8);
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 16);
+.cta-win-section {
+  grid-column: 1 / -1;
+  background: var(--color-win-gray-light);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+.cta-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 1100px;
+}
+
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
   align-items: center;
+  gap: 4px;
+  user-select: none;
 }
 
-.content {
-  grid-column: 1/-1;
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.cta-win-body {
+  display: grid;
+  grid-template-columns: 1fr;
+  min-height: 300px;
 
   @media (min-width: 700px) {
-    grid-column: 1/6;
-
-    &.is-flipped {
-      grid-column: -7/-1;
-      grid-row: 1;
-    }
+    grid-template-columns: 1.2fr 1fr;
   }
+}
 
-  @media (min-width: 1024px) {
-    grid-column: 1/9;
+.is-flipped .cta-win-body {
+  @media (min-width: 700px) {
+    direction: rtl;
 
-    &.is-flipped {
-      grid-column: -9/-1;
-      grid-row: 1;
+    > * {
+      direction: ltr;
     }
   }
 }
 
-.image {
-  grid-column: 1/-1;
-  height: unset;
-  aspect-ratio: 16/9;
+.cta-win-image {
+  position: relative;
+  overflow: hidden;
+  min-height: 220px;
+  border-right: 2px solid #808080;
+  box-shadow: inset -2px 0 0 #ffffff;
+  display: block;
+  text-decoration: none;
+}
 
-  @media (min-width: 700px) {
-    grid-column: 6/-1;
+.is-flipped .cta-win-image {
+  border-right: none;
+  border-left: 2px solid #808080;
+  box-shadow: inset 2px 0 0 #ffffff;
+}
 
-    &.is-flipped {
-      grid-column: 1/7;
-      grid-row: 1;
-    }
-  }
+.cta-win-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.6) contrast(0.85);
+  display: block;
+}
 
-  @media (min-width: 1024px) {
-    grid-column: 9/-1;
+.cta-win-img-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(0,0,128,0.15) 0%, transparent 60%);
+  pointer-events: none;
+}
 
-    &.is-flipped {
-      grid-column: 1/17;
-      grid-row: 1;
-    }
-  }
+.cta-win-text {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  margin: 8px;
+}
 
-  img {
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-  }
+.cta-win-text-inner {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cta-win-body-text {
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cta-win-separator {
+  height: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+}
+
+.cta-win-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", sans-serif;
+  font-size: 11px;
+  padding: 3px 14px 4px;
+  cursor: pointer;
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  min-width: 75px;
+  text-align: center;
+}
+
+.win-button:active {
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 14px 3px;
+}
+
+.win-button-primary {
+  outline: 1px solid #000;
+  outline-offset: -1px;
+}
+
+.cta-win-status {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 </style>

--- a/app/components/hero-banner.vue
+++ b/app/components/hero-banner.vue
@@ -12,12 +12,654 @@ const { data: hero } = useAsyncData<HomeHero>("home-hero", () => $fetch("/api/ho
 
 <template>
   <section
-    v-if="hero"
-    class="hero overflow-hidden grid"
+    class="hero-win"
     aria-labelledby="hero-title"
     aria-describedby="hero-summary"
     role="region"
   >
+    <!-- Marquee ticker at top -->
+    <div class="win-marquee-bar" aria-hidden="true">
+      <div class="win-marquee-track">
+        <span>*** ENVISION CONSTRUCTION SERVICES *** Complex Projects. Simple Accountability. *** Established 2009 *** $180M+ Project Delivery *** 90% Repeat Clients *** Central Florida Coverage *** Click "Start your project" to get started! ***&nbsp;&nbsp;&nbsp;</span>
+        <span>*** ENVISION CONSTRUCTION SERVICES *** Complex Projects. Simple Accountability. *** Established 2009 *** $180M+ Project Delivery *** 90% Repeat Clients *** Central Florida Coverage *** Click "Start your project" to get started! ***&nbsp;&nbsp;&nbsp;</span>
+      </div>
+    </div>
+
+    <!-- Main window panel -->
+    <div class="win-hero-window">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span class="win-titlebar-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect width="14" height="14" fill="#1084d0"/>
+            <rect x="2" y="2" width="10" height="10" fill="#ffffff" opacity="0.3"/>
+            <text x="2" y="11" font-size="9" fill="white" font-weight="bold">E</text>
+          </svg>
+        </span>
+        <span>Envision CS - Home</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1" aria-hidden="true">_</button>
+          <button class="win-titlebar-btn" tabindex="-1" aria-hidden="true">&#9633;</button>
+          <button class="win-titlebar-btn win-titlebar-btn--close" tabindex="-1" aria-hidden="true">&#x2715;</button>
+        </div>
+      </div>
+
+      <!-- Menu bar inside window -->
+      <div class="win-menubar" aria-hidden="true">
+        <span class="win-menubar-item">File</span>
+        <span class="win-menubar-item">Edit</span>
+        <span class="win-menubar-item">View</span>
+        <span class="win-menubar-item">Favorites</span>
+        <span class="win-menubar-item">Tools</span>
+        <span class="win-menubar-item">Help</span>
+      </div>
+
+      <!-- Toolbar -->
+      <div class="win-toolbar" aria-hidden="true">
+        <button class="win-toolbar-btn" tabindex="-1">&#9664; Back</button>
+        <button class="win-toolbar-btn" tabindex="-1">Forward &#9654;</button>
+        <button class="win-toolbar-btn win-toolbar-btn--stop" tabindex="-1">&#x25A0; Stop</button>
+        <button class="win-toolbar-btn" tabindex="-1">&#8635; Refresh</button>
+        <button class="win-toolbar-btn" tabindex="-1">&#x2302; Home</button>
+        <div class="win-address-bar">
+          <span class="win-address-label">Address</span>
+          <span class="win-address-input">http://www.envisioncs.com/</span>
+          <button class="win-address-go" tabindex="-1">Go</button>
+        </div>
+      </div>
+
+      <!-- Content area with image -->
+      <div class="win-hero-content">
+        <div class="win-hero-image-area">
+          <NuxtImg
+            v-if="hero?.image?.url"
+            :src="hero.image.url"
+            alt="Exterior view of a residence hall at dusk"
+            sizes="100vw sm:640px md:768px lg:1024px xl:1280px"
+            fit="cover"
+            preload
+            format="avif"
+            loading="eager"
+            class="win-hero-img"
+          />
+          <div v-else class="win-hero-img-placeholder" />
+        </div>
+
+        <div class="win-hero-text-panel">
+          <!-- Inner window for text -->
+          <div class="win-inner-window">
+            <div class="win-titlebar win-titlebar--secondary" role="presentation">
+              <span>Project Overview</span>
+            </div>
+            <div class="win-inner-content">
+              <h2 id="hero-title" class="win-hero-title">
+                Complex Projects.<br>Simple Accountability
+              </h2>
+              <hr class="win-separator-h">
+              <p id="hero-summary" class="win-hero-summary">
+                Local responsiveness. National-level expertise. Zero guesswork on your timeline or budget.
+              </p>
+              <hr class="win-separator-h">
+              <div class="win-hero-actions">
+                <NuxtLink to="/contact" class="win-button win-button-primary">Start your project</NuxtLink>
+                <NuxtLink to="/projects" class="win-button">Explore Portfolio</NuxtLink>
+              </div>
+              <div class="win-status-bar win-hero-status">
+                <span>&#9679;</span>
+                <span>Ready</span>
+                <div class="win-separator-v" style="height:14px" />
+                <span>Tampa, FL</span>
+                <div class="win-separator-v" style="height:14px" />
+                <span>Est. 2009</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Stats panel -->
+          <div class="win-stats-panel">
+            <div class="win-titlebar win-titlebar--secondary" role="presentation">
+              <span>Company Statistics</span>
+            </div>
+            <div class="win-stats-grid">
+              <div class="win-stat-item">
+                <span class="win-stat-value">2009</span>
+                <span class="win-stat-label">Established</span>
+              </div>
+              <div class="win-stat-divider" />
+              <div class="win-stat-item">
+                <span class="win-stat-value">$180M+</span>
+                <span class="win-stat-label">Project Delivery</span>
+              </div>
+              <div class="win-stat-divider" />
+              <div class="win-stat-item">
+                <span class="win-stat-value">90%</span>
+                <span class="win-stat-label">Repeat Clients</span>
+              </div>
+              <div class="win-stat-divider" />
+              <div class="win-stat-item">
+                <span class="win-stat-value">FL</span>
+                <span class="win-stat-label">Coverage</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Status bar at bottom -->
+      <div class="win-hero-bottom-status" aria-hidden="true">
+        <div class="win-status-bar">
+          <span class="win-status-icon">&#x1F310;</span>
+          <span>Done</span>
+          <div class="win-sep-v" />
+          <span>Internet zone</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Win2K taskbar at very bottom -->
+    <div class="win-taskbar" aria-hidden="true">
+      <button class="win-start-btn">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><rect width="7" height="7" fill="#FF0000"/><rect x="7" y="0" width="7" height="7" fill="#00AA00"/><rect x="0" y="7" width="7" height="7" fill="#0000FF"/><rect x="7" y="7" width="7" height="7" fill="#FFFF00"/></svg>
+        <strong>Start</strong>
+      </button>
+      <div class="win-taskbar-sep" />
+      <button class="win-task-item win-task-item--active">
+        <span>&#128196;</span> Envision CS - Home
+      </button>
+      <button class="win-task-item">
+        <span>&#128196;</span> Our Projects
+      </button>
+      <div class="win-taskbar-right">
+        <span class="win-tray-icon">&#128266;</span>
+        <span class="win-tray-icon">&#128246;</span>
+        <span class="win-clock">{{ new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) }}</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero-win {
+  grid-column: 1 / -1;
+  background: var(--color-win-teal);
+  background-image:
+    radial-gradient(circle at 30% 40%, rgba(0,128,128,0.6) 0%, transparent 50%),
+    radial-gradient(circle at 70% 60%, rgba(0,0,128,0.3) 0%, transparent 50%);
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 8px 8px 0;
+}
+
+/* Marquee bar */
+.win-marquee-bar {
+  background: var(--color-win-navy);
+  color: #ffffff;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  height: 20px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  box-shadow: var(--win-border-sunken);
+  flex-shrink: 0;
+}
+
+.win-marquee-track {
+  display: flex;
+  white-space: nowrap;
+  animation: win-marquee-scroll 30s linear infinite;
+}
+
+@keyframes win-marquee-scroll {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+/* Main window */
+.win-hero-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised), 6px 6px 0 rgba(0,0,0,0.4);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Title bar */
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #ffffff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.win-titlebar--secondary {
+  font-size: 10px;
+  padding: 2px 4px;
+}
+
+.win-titlebar-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  font-family: "Tahoma", sans-serif;
+}
+
+.win-titlebar-btn--close:hover {
+  background: #cc0000;
+  color: white;
+}
+
+/* Menu bar */
+.win-menubar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--color-win-gray-light);
+  padding: 2px 4px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  border-bottom: 1px solid #808080;
+  flex-shrink: 0;
+}
+
+.win-menubar-item {
+  padding: 2px 8px;
+  cursor: default;
+  user-select: none;
+}
+
+.win-menubar-item:hover {
+  background: var(--color-win-highlight);
+  color: var(--color-win-highlight-text);
+}
+
+/* Toolbar */
+.win-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--color-win-gray-light);
+  padding: 3px 6px;
+  border-bottom: 2px solid #808080;
+  box-shadow: 0 2px 0 #ffffff;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.win-toolbar-btn {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  padding: 2px 8px 3px;
+  cursor: pointer;
+  border: 0;
+  white-space: nowrap;
+}
+
+.win-toolbar-btn:active {
+  box-shadow: var(--win-border-sunken);
+}
+
+.win-toolbar-btn--stop {
+  color: #cc0000;
+}
+
+.win-address-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  margin-left: 8px;
+}
+
+.win-address-label {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  white-space: nowrap;
+  color: var(--color-win-black);
+}
+
+.win-address-input {
+  flex: 1;
+  min-width: 0;
+  background: #ffffff;
+  box-shadow: var(--win-border-sunken);
+  padding: 2px 6px;
+  font-size: 11px;
+  font-family: "Courier New", monospace;
+  color: var(--color-win-navy);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.win-address-go {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  padding: 2px 8px 3px;
+  cursor: pointer;
+  border: 0;
+}
+
+/* Content area */
+.win-hero-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+
+  @media (min-width: 768px) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (min-width: 1200px) {
+    grid-template-columns: 1.5fr 1fr;
+  }
+}
+
+.win-hero-image-area {
+  position: relative;
+  overflow: hidden;
+  min-height: 200px;
+  border-right: 2px solid #808080;
+}
+
+.win-hero-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.7) contrast(0.9);
+  display: block;
+}
+
+.win-hero-img-placeholder {
+  width: 100%;
+  height: 100%;
+  background: #336699;
+}
+
+/* Text panel */
+.win-hero-text-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  overflow-y: auto;
+  background: var(--color-win-gray-light);
+}
+
+/* Inner window */
+.win-inner-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+}
+
+.win-inner-content {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.win-hero-title {
+  font-size: clamp(16px, 2.5vw, 26px);
+  font-weight: bold;
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+  color: var(--color-win-navy);
+  line-height: 1.25;
+  margin: 0;
+}
+
+.win-hero-summary {
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  line-height: 1.45;
+  margin: 0;
+}
+
+.win-separator-h {
+  height: 0;
+  border: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+  margin: 4px 0;
+}
+
+.win-hero-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+  font-size: 11px;
+  padding: 3px 14px 4px;
+  cursor: pointer;
+  border: 0;
+  text-decoration: none;
+  display: inline-block;
+  min-width: 75px;
+  text-align: center;
+}
+
+.win-button:active {
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 14px 3px;
+}
+
+.win-button-primary {
+  outline: 1px solid #000;
+  outline-offset: -1px;
+}
+
+.win-hero-status {
+  font-size: 10px;
+  margin-top: 4px;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.win-sep-v {
+  width: 1px;
+  background: #808080;
+  align-self: stretch;
+}
+
+/* Stats panel */
+.win-stats-panel {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+}
+
+.win-stats-grid {
+  display: flex;
+  align-items: stretch;
+  padding: 8px 12px;
+  gap: 0;
+}
+
+.win-stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  padding: 4px 8px;
+}
+
+.win-stat-divider {
+  width: 1px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
+  align-self: stretch;
+  margin: 4px 0;
+}
+
+.win-stat-value {
+  font-size: 16px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  line-height: 1;
+}
+
+.win-stat-label {
+  font-size: 9px;
+  font-family: "Tahoma", sans-serif;
+  color: #404040;
+  text-align: center;
+  line-height: 1.2;
+}
+
+/* Bottom status */
+.win-hero-bottom-status {
+  flex-shrink: 0;
+}
+
+/* Taskbar */
+.win-taskbar {
+  background: var(--color-win-gray-light);
+  box-shadow:
+    inset 0 1px 0 #ffffff,
+    inset 0 2px 0 #d4d0c8;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  flex-shrink: 0;
+  margin-top: 8px;
+  position: relative;
+  z-index: 10;
+}
+
+.win-start-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  border: 0;
+  padding: 2px 8px 3px 6px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  font-weight: bold;
+  cursor: pointer;
+  height: 22px;
+}
+
+.win-start-btn:active {
+  box-shadow: var(--win-border-sunken);
+}
+
+.win-taskbar-sep {
+  width: 2px;
+  height: 100%;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #ffffff;
+  margin: 0 2px;
+}
+
+.win-task-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  border: 0;
+  padding: 2px 10px 3px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  cursor: pointer;
+  height: 22px;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.win-task-item--active {
+  box-shadow: var(--win-border-sunken);
+  font-weight: bold;
+}
+
+.win-taskbar-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  box-shadow: var(--win-border-sunken);
+  padding: 2px 8px;
+  height: 22px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+}
+
+.win-tray-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.win-clock {
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+}
+</style>
     <div class="col-span-full row-span-full">
       <NuxtImg
         v-if="hero.image?.url"

--- a/app/components/proven-process.vue
+++ b/app/components/proven-process.vue
@@ -1,10 +1,4 @@
 <script setup lang="ts">
-// const { data: our_process, pending, error } = await useAsyncData('our-process', () => $fetch('/api/process'), {
-//  server: true,
-//  lazy: true,
-//  default: () => [],
-// });
-
 const process = [
   {
     id: 1,
@@ -32,94 +26,265 @@ const process = [
     order: "04",
     title: "Cultivate",
     description:
-      "Our work doesn’t end at closeout. We stay engaged with system training, 30-60-90 day check-ins, and a one-year walkthrough. The goal: ensure your space performs, your team is supported, and your trust in us grows long after the build is done.",
+      "Our work doesn't end at closeout. We stay engaged with system training, 30-60-90 day check-ins, and a one-year walkthrough. The goal: ensure your space performs, your team is supported, and your trust in us grows long after the build is done.",
   },
 ];
 </script>
 
 <template>
-  <section>
-    <div class="content">
-      <app-typography tag="h2" variant="heading-lg" bold="true">
-        Our Proven Process
-      </app-typography>
-
-      <app-typography tag="h2">
-        Our proven process brings structure and consistency to every project. We listen, plan, and
-        execute to reduce risk, maintain alignment, and deliver on time, on budget, and with
-        complete transparency.
-      </app-typography>
-    </div>
-
-    <ul>
-      <li v-for="item in process" :key="item.id" class="flex flex-col gap-4">
-        <div class="grid gap-2">
-          <app-typography tag="h3" variant="heading-lg" class="number font-semibold">
-            {{ item.order }}
-          </app-typography>
-          <app-typography tag="h3" variant="heading-lg" class="font-semibold">
-            {{ item.title }}
-          </app-typography>
+  <section class="process-win-section">
+    <div class="process-win-window">
+      <!-- Window title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>Our Proven Process</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
         </div>
-        <app-typography tag="p">
-          {{ item.description }}
-        </app-typography>
-      </li>
-    </ul>
+      </div>
+
+      <!-- Description panel -->
+      <div class="process-win-desc">
+        <div class="process-win-desc-inner">
+          <p>
+            Our proven process brings structure and consistency to every project. We listen, plan, and
+            execute to reduce risk, maintain alignment, and deliver on time, on budget, and with
+            complete transparency.
+          </p>
+        </div>
+      </div>
+
+      <!-- Tabs (decorative) -->
+      <div class="process-win-tabs" aria-hidden="true">
+        <button class="process-win-tab process-win-tab--active">Phases</button>
+        <button class="process-win-tab">Timeline</button>
+        <button class="process-win-tab">Tools</button>
+      </div>
+
+      <!-- Process steps grid -->
+      <div class="process-win-body">
+        <ul class="process-win-list">
+          <li v-for="(item, idx) in process" :key="item.id" class="process-win-item">
+            <div class="process-win-item-inner">
+              <!-- Step number as folder icon -->
+              <div class="process-win-icon">
+                <svg width="32" height="28" viewBox="0 0 32 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M0 4h12l4 4h16v20H0V4z" :fill="idx === 0 ? '#1084d0' : idx === 1 ? '#008000' : idx === 2 ? '#808080' : '#404080'" />
+                  <path d="M0 2h10l2 2h-12z" :fill="idx === 0 ? '#1084d0' : idx === 1 ? '#008000' : idx === 2 ? '#808080' : '#404080'" opacity="0.7"/>
+                  <text x="16" y="22" text-anchor="middle" font-size="12" font-weight="bold" fill="white" font-family="Tahoma">{{ item.order }}</text>
+                </svg>
+              </div>
+              <h3 class="process-win-title">{{ item.title }}</h3>
+              <p class="process-win-text">{{ item.description }}</p>
+              <div class="process-win-footer">
+                <span class="process-win-badge">Step {{ item.order }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="win-status-bar process-win-status">
+        <span>&#9679;</span>
+        <span>4 steps</span>
+        <div class="process-sep" />
+        <span>Envision CS Methodology</span>
+      </div>
+    </div>
   </section>
 </template>
 
 <style scoped>
-section {
-  display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
-  gap: calc(var(--spacing) * 8);
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 16);
+.process-win-section {
+  grid-column: 1 / -1;
+  background: var(--color-win-gray-light);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
 }
 
-.content {
-  grid-column: 1/-1;
+.process-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 1100px;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 2);
 }
 
-ul {
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.process-win-desc {
+  padding: 8px;
+}
+
+.process-win-desc-inner {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 10px 12px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  line-height: 1.5;
+
+  p {
+    margin: 0;
+  }
+}
+
+.process-win-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 8px;
+  border-bottom: 2px solid #808080;
+}
+
+.process-win-tab {
+  background: var(--color-win-gray-light);
+  color: var(--color-win-black);
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 12px 4px;
+  border: 0;
+  cursor: pointer;
+  border-top: 2px solid #ffffff;
+  border-left: 1px solid #808080;
+  border-right: 1px solid #808080;
+  margin-bottom: -2px;
+  position: relative;
+}
+
+.process-win-tab--active {
+  background: var(--color-win-gray-light);
+  border-bottom: 2px solid var(--color-win-gray-light);
+  font-weight: bold;
+  z-index: 1;
+}
+
+.process-win-body {
+  padding: 8px;
+  background: var(--color-win-gray-light);
+}
+
+.process-win-list {
   display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
-  gap: calc(var(--spacing) * 8);
-}
-
-li {
-  padding: calc(var(--spacing) * 3);
-  grid-column: span 2;
-
-  @media (min-width: 700px) {
-    grid-column: span 6;
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (min-width: 1024px) {
-    grid-column: span 6;
+  @media (min-width: 900px) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 
-li:nth-child(1) {
-  background-color: var(--color-envision-blue-600);
+.process-win-item {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
 }
 
-li:nth-child(2) {
-  background-color: var(--color-envision-green-500);
+.process-win-item-inner {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
 }
 
-li:nth-child(3) {
-  background-color: var(--color-envision-gray-700);
+.process-win-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-li:nth-child(4) {
-  background-color: #435a66;
+.process-win-title {
+  font-size: 14px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  margin: 0;
+  text-align: center;
+}
+
+.process-win-text {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  line-height: 1.45;
+  margin: 0;
+  flex: 1;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 8px;
+}
+
+.process-win-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.process-win-badge {
+  font-size: 9px;
+  font-family: "Tahoma", sans-serif;
+  color: #606060;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 1px 6px;
+}
+
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.process-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
 }
 </style>

--- a/app/components/quote.vue
+++ b/app/components/quote.vue
@@ -50,7 +50,6 @@ const canScrollNext = ref(false);
 function syncCarouselState() {
   const api = emblaApi.value;
   if (!api) return;
-
   selectedIndex.value = api.selectedScrollSnap();
   scrollSnaps.value = api.scrollSnapList();
   canScrollPrevious.value = api.canScrollPrev();
@@ -62,31 +61,18 @@ const scrollNext = () => emblaApi.value?.scrollNext();
 const scrollTo = (index: number) => emblaApi.value?.scrollTo(index);
 
 function handleKeydown(event: KeyboardEvent) {
-  if (event.key === "ArrowLeft") {
-    event.preventDefault();
-    scrollPrevious();
-  }
-
-  if (event.key === "ArrowRight") {
-    event.preventDefault();
-    scrollNext();
-  }
+  if (event.key === "ArrowLeft") { event.preventDefault(); scrollPrevious(); }
+  if (event.key === "ArrowRight") { event.preventDefault(); scrollNext(); }
 }
 
-watch(
-  emblaApi,
-  (api, previousApi) => {
-    previousApi?.off("select", syncCarouselState);
-    previousApi?.off("reInit", syncCarouselState);
-
-    if (!api) return;
-
-    syncCarouselState();
-    api.on("select", syncCarouselState);
-    api.on("reInit", syncCarouselState);
-  },
-  { immediate: true },
-);
+watch(emblaApi, (api, previousApi) => {
+  previousApi?.off("select", syncCarouselState);
+  previousApi?.off("reInit", syncCarouselState);
+  if (!api) return;
+  syncCarouselState();
+  api.on("select", syncCarouselState);
+  api.on("reInit", syncCarouselState);
+}, { immediate: true });
 
 onUnmounted(() => {
   emblaApi.value?.off("select", syncCarouselState);
@@ -95,216 +81,239 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <section v-if="hasTestimonials" class="testimonials-stage">
-    <div class="testimonials-stage__inner">
-      <header class="testimonials-stage__header">
-        <app-typography
-          v-if="eyebrow"
-          tag="p"
-          variant="eyebrow-md"
-          class="testimonials-stage__eyebrow"
-        >
-          {{ eyebrow }}
-        </app-typography>
+  <section class="quotes-win-section">
+    <div class="quotes-win-window" v-if="hasTestimonials">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>{{ eyebrow }}</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
+        </div>
+      </div>
 
-        <app-typography tag="h2" variant="heading-md" class="testimonials-stage__title">
-          {{ sectionTitle }}
-        </app-typography>
+      <!-- Header text -->
+      <div class="quotes-win-header">
+        <div class="quotes-win-header-inner">
+          <p class="quotes-win-title">{{ sectionTitle }}</p>
+          <p v-if="sectionBody" class="quotes-win-body">{{ sectionBody }}</p>
+        </div>
+      </div>
 
-        <app-typography
-          v-if="sectionBody"
-          tag="p"
-          variant="text-lg"
-          class="testimonials-stage__body"
-        >
-          {{ sectionBody }}
-        </app-typography>
-      </header>
-
-      <div class="testimonials-stage__carousel">
-        <button
-          v-if="showRailNavigation"
-          type="button"
-          class="testimonials-stage__arrow testimonials-stage__arrow--previous"
-          :disabled="!canScrollPrevious"
-          aria-label="Previous testimonial"
-          @click="scrollPrevious"
-        >
-          <span aria-hidden="true">←</span>
-        </button>
+      <!-- Scrolling notepad area -->
+      <div class="quotes-win-notepad">
+        <div class="quotes-notepad-lines" aria-hidden="true">
+          <div v-for="i in 16" :key="i" class="quotes-notepad-line" />
+        </div>
 
         <div
           ref="emblaRef"
-          class="testimonials-stage__viewport"
+          class="quotes-win-viewport"
           :tabindex="showRailNavigation ? 0 : -1"
           aria-label="Client testimonials"
           @keydown="handleKeydown"
         >
-          <ul class="testimonials-stage__rail" role="list">
+          <ul class="quotes-win-rail" role="list">
             <li
               v-for="(testimonial, index) in normalizedTestimonials"
               :key="`${testimonial.name}-${index}`"
-              class="testimonials-stage__slide"
+              class="quotes-win-slide"
             >
-              <article class="testimonial">
-                <app-typography tag="p" variant="heading-sm" class="testimonial__quote">
-                  <span class="testimonial__mark" aria-hidden="true">“</span>
+              <article class="testimonial-win">
+                <p class="testimonial-win-quote">
+                  <span aria-hidden="true" class="testimonial-win-mark">"</span>
                   <span dir="auto">{{ testimonial.quote }}</span>
-                  <span class="testimonial__mark" aria-hidden="true">”</span>
-                </app-typography>
-
-                <div class="testimonial__meta">
-                  <app-typography tag="p" variant="text-md" class="testimonial__name">
-                    <span dir="auto">{{ testimonial.name }}</span>
-                  </app-typography>
-
-                  <app-typography tag="p" variant="text-sm" class="testimonial__title">
-                    <span dir="auto">{{ testimonial.title }}</span>
-                  </app-typography>
-
-                  <app-typography
-                    v-if="testimonial.detail"
-                    tag="p"
-                    variant="eyebrow-sm"
-                    class="testimonial__detail"
-                  >
-                    <span dir="auto">{{ testimonial.detail }}</span>
-                  </app-typography>
+                  <span aria-hidden="true" class="testimonial-win-mark">"</span>
+                </p>
+                <div class="testimonial-win-divider" />
+                <div class="testimonial-win-meta">
+                  <p class="testimonial-win-name">{{ testimonial.name }}</p>
+                  <p class="testimonial-win-title">{{ testimonial.title }}</p>
+                  <p v-if="testimonial.detail" class="testimonial-win-detail">
+                    {{ testimonial.detail }}
+                  </p>
                 </div>
               </article>
             </li>
           </ul>
         </div>
-
-        <button
-          v-if="showRailNavigation"
-          type="button"
-          class="testimonials-stage__arrow testimonials-stage__arrow--next"
-          :disabled="!canScrollNext"
-          aria-label="Next testimonial"
-          @click="scrollNext"
-        >
-          <span aria-hidden="true">→</span>
-        </button>
       </div>
 
-      <ul v-if="showRailNavigation" class="testimonials-stage__dots" aria-label="Testimonial pages">
-        <li v-for="(_, index) in scrollSnaps" :key="index" class="testimonials-stage__dot-item">
+      <!-- Navigation row -->
+      <div v-if="showRailNavigation" class="quotes-win-nav">
+        <button
+          class="win-button"
+          :disabled="!canScrollPrevious"
+          aria-label="Previous testimonial"
+          @click="scrollPrevious"
+        >&#9664; Prev</button>
+
+        <div class="quotes-win-dots" aria-label="Testimonial pages">
           <button
-            type="button"
-            class="testimonials-stage__dot"
+            v-for="(_, index) in scrollSnaps"
+            :key="index"
+            class="quotes-win-dot"
             :class="{ 'is-active': index === selectedIndex }"
             :aria-label="`Show testimonial ${index + 1}`"
             :aria-pressed="index === selectedIndex"
             @click="scrollTo(index)"
           />
-        </li>
-      </ul>
-    </div>
-  </section>
+        </div>
 
-  <section v-else class="quote-fallback">
-    <div class="quote-fallback__inner">
-      <app-typography
-        v-if="eyebrow"
-        tag="p"
-        variant="eyebrow-md"
-        class="testimonials-stage__eyebrow"
-      >
-        {{ eyebrow }}
-      </app-typography>
-      <app-typography variant="heading-sm" tag="p" class="quote-fallback__quote">
-        {{ quote || "Clients trust Envision to communicate clearly and follow through." }}
-      </app-typography>
-      <app-typography v-if="name" variant="text-lg" tag="p" class="quote-fallback__name">
-        {{ name }}
-      </app-typography>
-      <app-typography v-if="title" variant="text-md" tag="p" class="quote-fallback__title">
-        {{ title }}
-      </app-typography>
+        <button
+          class="win-button"
+          :disabled="!canScrollNext"
+          aria-label="Next testimonial"
+          @click="scrollNext"
+        >Next &#9654;</button>
+      </div>
+
+      <div class="win-status-bar quotes-win-status">
+        <span>&#9679;</span>
+        <span>{{ normalizedTestimonials.length }} testimonial(s)</span>
+        <div class="quotes-sep" />
+        <span>Showing {{ selectedIndex + 1 }} of {{ normalizedTestimonials.length }}</span>
+      </div>
+    </div>
+
+    <!-- Fallback -->
+    <div v-else class="quotes-win-window">
+      <div class="win-titlebar" role="presentation">
+        <span>{{ eyebrow }}</span>
+      </div>
+      <div class="quotes-win-notepad">
+        <p class="quotes-win-fallback-text">
+          "{{ quote || 'Clients trust Envision to communicate clearly and follow through.' }}"
+        </p>
+        <p v-if="name" class="quotes-win-name">{{ name }}</p>
+        <p v-if="title" class="quotes-win-attribution">{{ title }}</p>
+      </div>
     </div>
   </section>
 </template>
 
 <style scoped>
-.testimonials-stage,
-.quote-fallback {
+.quotes-win-section {
   grid-column: 1 / -1;
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 10);
-  color: var(--color-white);
+  background: var(--color-win-gray-light);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
 }
 
-.testimonials-stage__inner,
-.quote-fallback__inner {
-  display: grid;
-  gap: calc(var(--spacing) * 8);
-  width: min(100%, 78rem);
-  margin-inline: auto;
+.quotes-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
 }
 
-.testimonials-stage__header {
-  display: grid;
-  justify-items: center;
-  gap: calc(var(--spacing) * 3);
-  text-align: center;
-}
-
-.testimonials-stage__eyebrow {
-  opacity: 0.72;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.testimonials-stage__title,
-.testimonials-stage__body,
-.testimonial__quote,
-.testimonial__name,
-.testimonial__title,
-.testimonial__detail,
-.quote-fallback__quote,
-.quote-fallback__name,
-.quote-fallback__title {
-  max-width: none;
-  color: var(--color-white);
-}
-
-.testimonials-stage :deep(p),
-.testimonials-stage :deep(span),
-.testimonials-stage :deep(h2),
-.quote-fallback :deep(p),
-.quote-fallback :deep(span) {
-  color: var(--color-white);
-}
-
-.testimonials-stage__title {
-  width: min(100%, 36rem);
-  text-align: center;
-  text-wrap: balance;
-}
-
-.testimonials-stage__body {
-  width: min(100%, 30rem);
-  opacity: 0.82;
-  line-height: 1.5;
-}
-
-.testimonials-stage__carousel {
-  position: relative;
-  display: grid;
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
   align-items: center;
+  gap: 4px;
+  user-select: none;
 }
 
-.testimonials-stage__viewport {
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.quotes-win-header {
+  padding: 8px;
+}
+
+.quotes-win-header-inner {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.quotes-win-title {
+  font-size: 13px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  margin: 0;
+  line-height: 1.35;
+}
+
+.quotes-win-body {
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  margin: 0;
+  line-height: 1.45;
+}
+
+/* Notepad area */
+.quotes-win-notepad {
+  position: relative;
+  margin: 8px;
+  background: #fffef5;
+  box-shadow: var(--win-border-sunken);
   overflow: hidden;
+  border-left: 4px solid #ffaaaa;
 }
 
-.testimonials-stage__viewport:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 4px;
+.quotes-notepad-lines {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  padding: 20px 0;
 }
 
-.testimonials-stage__rail {
+.quotes-notepad-line {
+  height: 1px;
+  background: #add8e6;
+  opacity: 0.5;
+}
+
+.quotes-win-viewport {
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+}
+
+.quotes-win-viewport:focus-visible {
+  outline: 1px dotted #000;
+  outline-offset: 2px;
+}
+
+.quotes-win-rail {
   display: flex;
   margin: 0;
   padding: 0;
@@ -312,186 +321,169 @@ onUnmounted(() => {
   touch-action: pan-y pinch-zoom;
 }
 
-.testimonials-stage__slide {
+.quotes-win-slide {
   flex: 0 0 100%;
   min-width: 0;
-  display: flex;
-  justify-content: center;
 }
 
-.testimonial {
-  display: grid;
-  justify-items: center;
-  gap: calc(var(--spacing) * 5);
-  width: min(100%, 44rem);
+.testimonial-win {
+  padding: 24px 20px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.testimonial-win-quote {
+  font-size: 14px;
+  font-family: "Times New Roman", serif;
+  font-style: italic;
+  color: var(--color-win-black);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.testimonial-win-mark {
+  font-size: 18px;
+  color: #808080;
+  font-style: normal;
+}
+
+.testimonial-win-divider {
+  height: 0;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #ffffff;
+}
+
+.testimonial-win-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.testimonial-win-name {
+  font-size: 11px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-navy);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.testimonial-win-title {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: #404040;
+  margin: 0;
+}
+
+.testimonial-win-detail {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  color: var(--color-win-black);
+  margin: 0;
+  padding: 2px 6px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  display: inline-block;
+  align-self: flex-start;
+}
+
+/* Nav row */
+.quotes-win-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  gap: 8px;
+  border-top: 2px solid #808080;
+  box-shadow: inset 0 2px 0 #ffffff;
+}
+
+.win-button {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  color: var(--color-win-black);
+  font-family: "Tahoma", sans-serif;
+  font-size: 11px;
+  padding: 3px 12px 4px;
+  cursor: pointer;
+  border: 0;
+  min-width: 70px;
   text-align: center;
 }
 
-.testimonial__quote {
-  width: min(100%, 42rem);
-  font-style: italic;
-  line-height: 1.55;
-  text-wrap: balance;
+.win-button:active {
+  box-shadow: var(--win-border-sunken);
+  padding: 4px 12px 3px;
 }
 
-.testimonial__mark {
-  opacity: 0.92;
+.win-button:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
-.testimonial__meta {
-  display: grid;
-  justify-items: center;
-  gap: calc(var(--spacing) * 1.5);
-}
-
-.testimonial__name {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.testimonial__title {
-  opacity: 0.7;
-}
-
-.testimonial__detail {
-  padding-inline: calc(var(--spacing) * 3);
-  padding-block: calc(var(--spacing) * 1);
-  border: 1px solid currentColor;
-  opacity: 0.9;
-}
-
-.testimonials-stage__arrow {
-  position: absolute;
-  top: 50%;
-  z-index: 1;
-  display: inline-flex;
+.quotes-win-dots {
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
-  border: 1px solid currentColor;
-  border-radius: 999px;
-  background: transparent;
-  color: inherit;
-  transform: translateY(-50%);
-  opacity: 0.45;
-  transition:
-    opacity 180ms ease,
-    transform 180ms ease;
+  gap: 4px;
 }
 
-.testimonials-stage__arrow:hover:not(:disabled),
-.testimonials-stage__arrow:focus-visible {
-  opacity: 1;
-}
-
-.testimonials-stage__arrow:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 3px;
-}
-
-.testimonials-stage__arrow:disabled {
-  opacity: 0.18;
-}
-
-.testimonials-stage__arrow--previous {
-  left: 0;
-}
-
-.testimonials-stage__arrow--next {
-  right: 0;
-}
-
-.testimonials-stage__dots {
-  display: flex;
-  justify-content: center;
-  gap: calc(var(--spacing) * 1.5);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.testimonials-stage__dot-item {
-  display: flex;
-}
-
-.testimonials-stage__dot {
-  width: 0.375rem;
-  height: 0.375rem;
+.quotes-win-dot {
+  width: 12px;
+  height: 12px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
   border: 0;
-  border-radius: 999px;
-  background: currentColor;
-  opacity: 0.22;
-  transition:
-    opacity 180ms ease,
-    transform 180ms ease;
+  cursor: pointer;
+  padding: 0;
 }
 
-.testimonials-stage__dot:hover,
-.testimonials-stage__dot:focus-visible,
-.testimonials-stage__dot.is-active {
-  opacity: 1;
+.quotes-win-dot.is-active {
+  background: var(--color-win-navy);
+  box-shadow: var(--win-border-sunken);
 }
 
-.testimonials-stage__dot.is-active {
-  transform: scale(1.15);
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.testimonials-stage__dot:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 3px;
+.quotes-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
 }
 
-.quote-fallback__inner {
-  justify-items: center;
-  text-align: center;
+.quotes-win-fallback-text {
+  font-size: 14px;
+  font-family: "Times New Roman", serif;
+  font-style: italic;
+  padding: 20px;
+  margin: 0;
 }
 
-.quote-fallback__quote {
-  width: min(100%, 42rem);
-  text-wrap: balance;
+.quotes-win-name {
+  font-size: 11px;
+  font-weight: bold;
+  font-family: "Tahoma", sans-serif;
+  padding: 0 20px;
+  margin: 0;
 }
 
-.quote-fallback__title {
-  opacity: 0.72;
-}
-
-@media (max-width: 767px) {
-  .testimonials-stage,
-  .quote-fallback {
-    padding-block: calc(var(--spacing) * 8);
-  }
-
-  .testimonials-stage__inner,
-  .quote-fallback__inner {
-    gap: calc(var(--spacing) * 6);
-  }
-
-  .testimonial {
-    width: min(100%, 32rem);
-  }
-
-  .testimonials-stage__arrow {
-    position: static;
-    transform: none;
-    margin-top: calc(var(--spacing) * 2);
-  }
-
-  .testimonials-stage__carousel {
-    gap: calc(var(--spacing) * 4);
-    justify-items: center;
-  }
-
-  .testimonials-stage__arrow--previous,
-  .testimonials-stage__arrow--next {
-    inset: auto;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .testimonials-stage__arrow,
-  .testimonials-stage__dot {
-    transition: none;
-  }
+.quotes-win-attribution {
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  padding: 0 20px 16px;
+  margin: 0;
+  color: #404040;
 }
 </style>

--- a/app/components/three-uniques.vue
+++ b/app/components/three-uniques.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-let ctx: unknown;
-const galleryRef = ref<HTMLElement | null>(null);
 
 const process = [
   {
@@ -11,131 +9,270 @@ const process = [
       "Our foundation is God, our work is built on integrity, and our mission is to serve with excellence.",
     image:
       "https://ik.imagekit.io/pnixsw7lg/main-website/20250519_134053.jpg?updatedAt=1771548280364",
-    color: "--color-envision-blue-600",
+    color: "#000080",
   },
   {
     id: 2,
     title: "Impact Beyond Construction",
     description:
-      "We don’t just build—we leave a mark. Every project is an opportunity to create something lasting, from the spaces we shape to the relationships we forge. With heart, craftsmanship, and purpose, we build legacies that elevate communities for generations to come.",
+      "We don't just build—we leave a mark. Every project is an opportunity to create something lasting, from the spaces we shape to the relationships we forge. With heart, craftsmanship, and purpose, we build legacies that elevate communities for generations to come.",
     image:
       "https://ik.imagekit.io/pnixsw7lg/main-website/117812314_10158747995319553_8729798724554644994_o.jpg?updatedAt=1771547653476",
-    color: "--color-envision-green-500",
+    color: "#008000",
   },
   {
     id: 3,
     title: "Versatile. Adaptive. Enhanced Approach",
     description:
-      "No two projects are the same, and neither is our approach. Whether it’s a small renovation or a large-scale build, we move with precision, flexibility, and care—delivering the personal attention of a local partner with the expertise of a national leader.",
+      "No two projects are the same, and neither is our approach. Whether it's a small renovation or a large-scale build, we move with precision, flexibility, and care—delivering the personal attention of a local partner with the expertise of a national leader.",
     image:
       "https://ik.imagekit.io/pnixsw7lg/main-website/USFSP%20Residence%20Hall%20-%20Dusk%20Window%20View%20to%20Locker.jpg?updatedAt=1771547653634",
-    color: "--color-envision-gray-700",
+    color: "#404040",
   },
 ];
 </script>
 
 <template>
-  <section class="wrapper site-grid">
-    <div class="content-wrapper">
-      <app-typography tag="h2" variant="heading-lg" bold="true">
-        Our<span> Three </span><span class="text-envision-blue-500">Uniques</span>
-      </app-typography>
-      <app-typography tag="p">
-        At Envision, every decision we make is guided by a clear philosophy—three core principles
-        that define how we work, why we work, and the impact we strive to create. These<span>
-          “Three Uniques”</span
-        >
-        are more than values; they are the driving force behind our approach, shaping every project,
-        partnership, and interaction
-      </app-typography>
-    </div>
-    <ul class="uniques-wrapper">
-      <li v-for="p in process" :key="p.id" class="unique">
-        <div class="content">
-          <app-typography tag="h3" variant="heading-md" class="title text-semibold">
-            {{ p.title }}
-          </app-typography>
-          <p>{{ p.description }}</p>
+  <section class="uniques-win-section">
+    <div class="uniques-win-window">
+      <!-- Title bar -->
+      <div class="win-titlebar" role="presentation">
+        <span>Our Three Uniques</span>
+        <div class="win-titlebar-buttons" aria-hidden="true">
+          <button class="win-titlebar-btn" tabindex="-1">_</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#9633;</button>
+          <button class="win-titlebar-btn" tabindex="-1">&#x2715;</button>
         </div>
-        <NuxtImg :src="p.image" provider="imagekit" fit="cover" class="image" />
-      </li>
-    </ul>
+      </div>
+
+      <!-- Intro text -->
+      <div class="uniques-win-intro">
+        <div class="uniques-intro-inner">
+          <p>
+            At Envision, every decision we make is guided by a clear philosophy—three core principles
+            that define how we work, why we work, and the impact we strive to create. These
+            <strong>"Three Uniques"</strong> are more than values; they are the driving force behind
+            our approach, shaping every project, partnership, and interaction.
+          </p>
+        </div>
+      </div>
+
+      <!-- Cards -->
+      <div class="uniques-win-body">
+        <ul class="uniques-win-list">
+          <li v-for="p in process" :key="p.id" class="unique-win-item">
+            <!-- Mini window for each unique -->
+            <div class="unique-win-card">
+              <div
+                class="win-titlebar unique-titlebar"
+                :style="{ background: `linear-gradient(to right, ${p.color}, ${p.color}aa)` }"
+                role="presentation"
+              >
+                <span>{{ p.title }}</span>
+              </div>
+              <div class="unique-win-image-wrap">
+                <NuxtImg
+                  :src="p.image"
+                  provider="imagekit"
+                  fit="cover"
+                  class="unique-win-img"
+                  :alt="p.title"
+                  loading="lazy"
+                />
+                <div
+                  class="unique-win-overlay"
+                  :style="{ background: `${p.color}99` }"
+                  aria-hidden="true"
+                />
+              </div>
+              <div class="unique-win-text">
+                <p>{{ p.description }}</p>
+              </div>
+              <div class="unique-win-status">
+                <span>&#9679;</span>
+                <span>Core Value #{{ p.id }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="win-status-bar uniques-win-status">
+        <span>&#9679;</span>
+        <span>3 core values</span>
+        <div class="uniques-sep" />
+        <span>Envision Construction Services Philosophy</span>
+      </div>
+    </div>
   </section>
 </template>
 
 <style scoped>
-section {
-  display: grid;
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
-  gap: calc(var(--spacing) * 8);
-  padding-inline: calc(var(--spacing) * 4);
-  padding-block: calc(var(--spacing) * 16);
+.uniques-win-section {
+  grid-column: 1 / -1;
+  background: var(--color-win-gray-light);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
 }
 
-.content-wrapper {
-  grid-column: 1/-1;
+.uniques-win-window {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  width: 100%;
+  max-width: 1100px;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 2);
 }
 
-.uniques-wrapper {
-  display: grid;
-  gap: calc(var(--spacing) * 4);
-  grid-column: 1/-1;
-  grid-template-columns: subgrid;
+.win-titlebar {
+  background: var(--win-titlebar);
+  color: #fff;
+  font-weight: bold;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  padding: 3px 4px 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+  flex-shrink: 0;
 }
 
-.unique {
+.win-titlebar-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+.win-titlebar-btn {
+  width: 16px;
+  height: 14px;
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-button);
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--color-win-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+
+.uniques-win-intro {
+  padding: 8px;
+}
+
+.uniques-intro-inner {
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  padding: 10px 12px;
+  font-size: 11px;
+  font-family: "Tahoma", sans-serif;
+  line-height: 1.5;
+
+  p { margin: 0; }
+}
+
+.uniques-win-body {
+  padding: 8px;
+}
+
+.uniques-win-list {
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.unique-win-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.unique-win-card {
+  background: var(--color-win-gray-light);
+  box-shadow: var(--win-border-raised);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.unique-titlebar {
+  font-size: 10px;
+  padding: 2px 6px;
+}
+
+.unique-win-image-wrap {
+  position: relative;
   overflow: hidden;
-  aspect-ratio: 3/4;
+  aspect-ratio: 4/3;
+}
 
-  grid-column: 1/-1;
+.unique-win-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(0.7) contrast(0.85);
+  display: block;
+}
 
-  @media (min-width: 700px) {
-    grid-column: span 4;
-  }
+.unique-win-overlay {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
 
-  @media (min-width: 1024px) {
-    grid-column: span 8;
-  }
+.unique-win-text {
+  padding: 10px;
+  background: var(--color-win-white);
+  box-shadow: var(--win-border-sunken);
+  margin: 6px;
+  flex: 1;
 
-  .content {
-    grid-column: 1/-1;
-    grid-row: 1/-1;
-    z-index: 1;
-    color: #fff;
-
-    place-self: end;
-    display: flex;
-    flex-direction: column;
-    gap: calc(var(--spacing) * 2);
-    padding: calc(var(--spacing) * 4);
-  }
-
-  .image {
-    grid-column: 1/-1;
-    grid-row: 1/-1;
-    height: 100%;
-    width: 100%;
-    filter: grayscale();
-    mix-blend-mode: multiply;
+  p {
+    font-size: 10px;
+    font-family: "Tahoma", sans-serif;
+    line-height: 1.45;
+    margin: 0;
   }
 }
 
-li:nth-child(1) {
-  background-color: var(--color-envision-blue-600);
+.unique-win-status {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-li:nth-child(2) {
-  background-color: var(--color-envision-green-500);
+.win-status-bar {
+  background: var(--color-win-gray-light);
+  border-top: 1px solid #808080;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-family: "Tahoma", sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-li:nth-child(3) {
-  background-color: var(--color-envision-gray-700);
+.uniques-sep {
+  width: 1px;
+  height: 12px;
+  background: #808080;
+  box-shadow: 1px 0 0 #ffffff;
 }
 </style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -17,10 +17,10 @@ const mainStyle = computed(() => {
 </script>
 
 <template>
-  <div>
+  <div class="win-desktop-bg">
     <app-header />
     <div class="">
-      <UMain :style="mainStyle">
+      <UMain :style="mainStyle" class="win-main">
         <slot />
       </UMain>
     </div>
@@ -29,21 +29,12 @@ const mainStyle = computed(() => {
 </template>
 
 <style scoped>
-.divider {
-  position: relative;
+.win-desktop-bg {
+  background-color: var(--color-win-teal);
+  min-height: 100dvh;
 }
 
-.divider::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: 0px;
-  height: 100%;
-  background-color: var(--ui-border);
-
-  @media (min-width: 800px) {
-    width: 1px;
-  }
+.win-main {
+  background: var(--color-win-gray-light);
 }
 </style>


### PR DESCRIPTION
## Windows 2000 Redesign

This PR transforms the entire homepage into a faithful Microsoft Windows 2000 / early 2000s web aesthetic.

### Changes

**Global CSS (`main.css`)**
- Complete color system overhaul: classic Win2K gray (`#d4d0c8`), teal desktop (`#008080`), navy title bars (`#000080`), Windows white, and black
- Win2K beveled border utility variables (`--win-border-raised`, `--win-border-sunken`, `--win-border-button`)
- Tahoma/MS Sans Serif typography stack
- Scrollbar styled to classic Windows chrome
- Utility classes: `.win-panel`, `.win-titlebar`, `.win-button`, `.win-status-bar`, etc.

**Components redesigned**
- `hero-banner.vue` — Full window chrome with IE-style toolbar, address bar, marquee ticker, taskbar with Start button and clock
- `company-stats.vue` — Raised window panel with sunken stat cells
- `cta-a.vue` — Window with title bar, image pane with desaturated filter, text in sunken panel
- `card-group-a.vue` — File explorer window with toolbar (Large Icons/Details/List), folder-style cards
- `proven-process.vue` — Window with tab chrome (Phases/Timeline/Tools), folder icon SVGs per step
- `three-uniques.vue` — Three mini windows with custom colored title bars per unique
- `quote.vue` — Notepad-style panel (lined paper, red margin line) with pagination dots as square Win2K buttons
- `app/header.vue` — Menu bar with hover highlight, dropdown panels styled as context menus
- `app/footer.vue` — Window panel with colored sub-headers per column
- `app/mobile-nav-drawer.vue` — Win2K dialog drawer
- `layouts/default.vue` — Teal desktop background wrapping the site