### PR TITLE
Add social icons to the header

### DIFF
--- a/app/components/app/mobile-nav-drawer.vue
+++ b/app/components/app/mobile-nav-drawer.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { socialLinks } from '~/utils/social-links';
+
 const mobileDrawerOpen = ref(false);
 const mobileServicesOpen = ref(false);
 const mobileProjectsOpen = ref(false);
@@ -479,6 +481,23 @@ function onDrawerCloseAutoFocus(event: Event) {
           </ul>
         </nav>
 
+        <div class="mobile-social">
+          <p class="mobile-social__title">Follow Envision</p>
+          <div class="mobile-social__links">
+            <a
+              v-for="social in socialLinks"
+              :key="social.name"
+              class="mobile-social__link"
+              :href="social.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              :aria-label="social.label"
+            >
+              <UIcon :name="social.icon" class="mobile-social__icon" aria-hidden="true" />
+            </a>
+          </div>
+        </div>
+
         <footer class="mobile-footer" aria-label="Secondary navigation">
           <div v-for="group in footerLinkGroups" :key="group.title" class="mobile-footer__group">
             <p class="mobile-footer__title">{{ group.title }}</p>
@@ -890,6 +909,67 @@ function onDrawerCloseAutoFocus(event: Event) {
   background: color-mix(in oklch, var(--drawer-accent) 16%, transparent);
 }
 
+.mobile-social {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing) * 4);
+  width: min(100%, 42rem);
+  margin-inline: auto;
+  padding: 0 calc(var(--spacing) * 3) calc(var(--spacing) * 6);
+}
+
+.mobile-social__title {
+  margin: 0;
+  color: var(--drawer-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.mobile-social__links {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing) * 2);
+}
+
+.mobile-social__link {
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 1px solid var(--drawer-border);
+  border-radius: calc(var(--spacing) * 2);
+  background: var(--drawer-surface);
+  color: color-mix(in oklch, var(--color-white) 82%, transparent);
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+
+.mobile-social__link:hover,
+.mobile-social__link:focus-visible {
+  color: #59ba48;
+  background: var(--drawer-surface-hover);
+}
+
+.mobile-social__link:focus-visible {
+  outline: 2px solid var(--drawer-accent);
+  outline-offset: -2px;
+}
+
+.mobile-social__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-social__link {
+    transition: none;
+  }
+}
+
 .mobile-footer {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -940,6 +1020,7 @@ function onDrawerCloseAutoFocus(event: Event) {
 @media (min-width: 480px) {
   .mobile-content-header,
   .mobile-nav,
+  .mobile-social,
   .mobile-footer {
     padding-inline: calc(var(--spacing) * 6);
   }

--- a/app/components/main-navigation.vue
+++ b/app/components/main-navigation.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { socialLinks } from '~/utils/social-links';
+
 const { sectors } = await useSectors();
 const { services } = await useServicesList();
 const posthog = usePostHog();
@@ -106,6 +108,22 @@ function handleProjectsClick() {
     </NuxtLink>
     <nav aria-label="Envision Construction Services">
       <ul role="menubar" aria-label="Envision Construction Services">
+        <li role="none" class="nav-social-item">
+          <span class="nav-social">
+            <a
+              v-for="social in socialLinks"
+              :key="social.name"
+              class="nav-social__link"
+              :href="social.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              :aria-label="social.label"
+            >
+              <UIcon :name="social.icon" class="nav-social__icon" aria-hidden="true" />
+            </a>
+            <span class="nav-social__divider" aria-hidden="true" />
+          </span>
+        </li>
         <li role="none">
           <NuxtLink role="menuitem" to="/">Home</NuxtLink>
         </li>
@@ -299,6 +317,59 @@ li {
       display: flex;
       opacity: 1;
     }
+  }
+}
+
+/* Social icons at the left end of the nav block, before the divider */
+.nav-social-item {
+  align-items: center;
+}
+
+.nav-social {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.nav-social__link {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border-radius: 0;
+  color: rgb(255 255 255 / 0.82);
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+
+.nav-social__link:hover,
+.nav-social__link:focus-visible {
+  color: #59ba48;
+  background: rgb(255 255 255 / 0.08);
+}
+
+.nav-social__link:focus-visible {
+  outline: 2px solid #59ba48;
+  outline-offset: -2px;
+}
+
+.nav-social__icon {
+  width: 17px;
+  height: 17px;
+}
+
+.nav-social__divider {
+  width: 1px;
+  height: 20px;
+  margin: 0 12px 0 8px;
+  background: rgb(255 255 255 / 0.22);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-social__link {
+    transition: none;
   }
 }
 

--- a/app/utils/social-links.ts
+++ b/app/utils/social-links.ts
@@ -1,0 +1,32 @@
+export interface SocialLink {
+  /** Network name, used as a stable key. */
+  name: string;
+  /** Accessible label for screen readers. */
+  label: string;
+  href: string;
+  /** Outline (not filled) Lucide icon name. */
+  icon: string;
+}
+
+// Order: LinkedIn, Instagram, Facebook. These are the canonical Envision handles,
+// shared by the header social icons and the About Us page.
+export const socialLinks: SocialLink[] = [
+  {
+    name: 'LinkedIn',
+    label: 'Envision on LinkedIn',
+    href: 'https://www.linkedin.com/company/envision-cs/',
+    icon: 'i-lucide-linkedin',
+  },
+  {
+    name: 'Instagram',
+    label: 'Envision on Instagram',
+    href: 'https://www.instagram.com/envisioncs_/',
+    icon: 'i-lucide-instagram',
+  },
+  {
+    name: 'Facebook',
+    label: 'Envision on Facebook',
+    href: 'https://www.facebook.com/envisioncstampa',
+    icon: 'i-lucide-facebook',
+  },
+];


### PR DESCRIPTION
Website 2.0 edits — Job 02. LinkedIn/Instagram/Facebook outline icons inside the nav block (design 1A), moving into the mobile menu below 1100px. Open in new tabs with screen-reader labels. Verified desktop + mobile + hover + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)