### PR TITLE
Fix About page prerender (remove undefined usePageView)

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -15,16 +15,6 @@ useSeoMeta({
   twitterImage: 'https://ik.imagekit.io/pnixsw7lg/main-website/MeetTheTeam.jpg',
 });
 
-usePageView({
-  eventName: 'about_page_viewed',
-  funnelEvent: {
-    funnel_stage: 'top',
-    conversion_role: 'secondary_action',
-    intent: 'low-medium',
-    funnel_movement: 'down',
-  },
-});
-
 // The Curator.io feed's published bundle looks for its container the moment it
 // runs, so the loader must execute AFTER the feed div is in the DOM (client-side
 // on mount) — never in <head>. Feed styling/layout lives in the Curator dashboard.


### PR DESCRIPTION
Hotfix: the About redesign called usePageView, which no longer exists in the codebase, so /about threw a 500 during prerender and failed the Vercel build. Removed the call (PostHog autocaptures pageviews globally). Verified: clean production build passes, /about prerenders real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)